### PR TITLE
Add local node Django GUI module

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ An AI assistant using computer vision to contextualise and interpret the world.
 This repository currently contains a skeleton implementation. See
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a description of the project
 layout and intended components.
+
+## Local Node GUI
+
+A minimal Django-based GUI is available for running a local Altinet node.
+To launch the development server:
+
+```bash
+python -m altinet.localnode.startup
+```
+
+By default the server binds to `127.0.0.1:8000`. You can override the host
+and port by passing arguments to `start_server`.

--- a/src/altinet/localnode/__init__.py
+++ b/src/altinet/localnode/__init__.py
@@ -1,0 +1,3 @@
+"""Local node module providing a simple Django-based GUI."""
+
+__all__ = ["startup"]

--- a/src/altinet/localnode/settings.py
+++ b/src/altinet/localnode/settings.py
@@ -1,0 +1,32 @@
+"""Minimal Django settings for the Altinet local node GUI."""
+
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent
+
+SECRET_KEY = "dev-secret-key"
+DEBUG = True
+ROOT_URLCONF = "altinet.localnode.urls"
+
+ALLOWED_HOSTS = ["*"]
+
+INSTALLED_APPS = [
+    "django.contrib.staticfiles",
+]
+
+MIDDLEWARE = [
+    "django.middleware.common.CommonMiddleware",
+]
+
+TEMPLATES = [
+    {
+        "BACKEND": "django.template.backends.django.DjangoTemplates",
+        "DIRS": [BASE_DIR / "templates"],
+        "APP_DIRS": True,
+        "OPTIONS": {
+            "context_processors": [],
+        },
+    }
+]
+
+STATIC_URL = "/static/"

--- a/src/altinet/localnode/startup.py
+++ b/src/altinet/localnode/startup.py
@@ -1,0 +1,24 @@
+"""Startup script for the Altinet local node GUI."""
+
+import os
+
+
+def start_server(host: str = "127.0.0.1", port: int = 8000) -> None:
+    """Start the Django development server for the local node GUI.
+
+    Parameters
+    ----------
+    host:
+        Hostname to bind the server to.
+    port:
+        Port number for the server.
+    """
+    try:
+        from django.core.management import call_command
+        import django
+    except ModuleNotFoundError as exc:  # pragma: no cover - runtime dependency
+        raise RuntimeError("Django must be installed to run the local node GUI") from exc
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "altinet.localnode.settings")
+    django.setup()
+    call_command("runserver", f"{host}:{port}")

--- a/src/altinet/localnode/templates/index.html
+++ b/src/altinet/localnode/templates/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>Altinet Local Node</title>
+</head>
+<body>
+    <h1>Altinet Local Node</h1>
+    <p>Welcome to the Altinet local node GUI.</p>
+</body>
+</html>

--- a/src/altinet/localnode/urls.py
+++ b/src/altinet/localnode/urls.py
@@ -1,0 +1,8 @@
+"""URL configuration for the Altinet local node GUI."""
+
+from django.urls import path
+from . import views
+
+urlpatterns = [
+    path("", views.home, name="home"),
+]

--- a/src/altinet/localnode/views.py
+++ b/src/altinet/localnode/views.py
@@ -1,0 +1,8 @@
+"""Views for the Altinet local node GUI."""
+
+from django.shortcuts import render
+
+
+def home(request):
+    """Render the landing page for the local node."""
+    return render(request, "index.html")


### PR DESCRIPTION
## Summary
- introduce `altinet.localnode` package with minimal Django settings, views and startup helper to run a development GUI
- add simple HTML template for landing page
- document how to launch the local node GUI in the README

## Testing
- `pip install django` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf876019b0832f9ccd3c048d3883d5