### PR TITLE
Add working memory service with prompt generation

### DIFF
--- a/src/altinet/altinet/services/__init__.py
+++ b/src/altinet/altinet/services/__init__.py
@@ -1,3 +1,3 @@
 """High level services for Altinet."""
 
-__all__ = ["discovery", "messaging"]
+__all__ = ["discovery", "messaging", "memory"]

--- a/src/altinet/altinet/services/memory.py
+++ b/src/altinet/altinet/services/memory.py
@@ -1,0 +1,69 @@
+"""Working memory and prompt construction utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+
+@dataclass
+class Person:
+    """Represents an observed person."""
+
+    name: str
+    location: Optional[str] = None
+
+
+@dataclass
+class EnvironmentContext:
+    """Contextual information about the environment."""
+
+    time: datetime
+    temperature_c: Optional[float] = None
+    location: Optional[str] = None
+
+
+@dataclass
+class WorkingMemory:
+    """Collects details about people and environment context."""
+
+    people: List[Person] = field(default_factory=list)
+    context: Optional[EnvironmentContext] = None
+
+    def add_person(self, name: str, location: Optional[str] = None) -> None:
+        """Add a person to the working memory."""
+
+        self.people.append(Person(name=name, location=location))
+
+    def update_context(
+        self, *, temperature_c: Optional[float] = None, location: Optional[str] = None
+    ) -> None:
+        """Update the environmental context using the current time."""
+
+        self.context = EnvironmentContext(
+            time=datetime.now(), temperature_c=temperature_c, location=location
+        )
+
+    def build_prompt(self) -> str:
+        """Return a prompt string summarising the current memory."""
+
+        pieces: List[str] = []
+        if self.context:
+            time_str = self.context.time.strftime("%Y-%m-%d %H:%M:%S")
+            temp = (
+                f"{self.context.temperature_c:.1f}\u00b0C"
+                if self.context.temperature_c is not None
+                else "unknown temperature"
+            )
+            loc = self.context.location or "unknown location"
+            pieces.append(f"The current time is {time_str} at {loc} with {temp}.")
+        if self.people:
+            people_desc = ", ".join(
+                f"{p.name}" + (f" in {p.location}" if p.location else "")
+                for p in self.people
+            )
+            pieces.append(f"People present: {people_desc}.")
+        else:
+            pieces.append("No people are currently detected.")
+        return " ".join(pieces)

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,21 @@
+"""Tests for the working memory module."""
+
+from altinet.services.memory import WorkingMemory
+
+
+def test_build_prompt_with_context_and_people() -> None:
+    wm = WorkingMemory()
+    wm.add_person("Alice", location="kitchen")
+    wm.update_context(temperature_c=21.5, location="kitchen")
+    prompt = wm.build_prompt()
+    assert "Alice" in prompt
+    assert "21.5" in prompt
+    assert "kitchen" in prompt
+
+
+def test_build_prompt_no_people() -> None:
+    wm = WorkingMemory()
+    wm.update_context(temperature_c=18.0, location="office")
+    prompt = wm.build_prompt()
+    assert "No people are currently detected." in prompt
+    assert "office" in prompt


### PR DESCRIPTION
## Summary
- add `WorkingMemory` service to collect people and environment context
- generate base prompt string for LLMs from current memory
- cover working memory behavior with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf9ca73c00832f99bc531b3424c73c