### PR TITLE
Add user preferences database

### DIFF
--- a/src/altinet/altinet/localnode/models.py
+++ b/src/altinet/altinet/localnode/models.py
@@ -1,0 +1,32 @@
+"""Database models for the local node GUI.
+
+These models provide a minimal schema for storing users and their
+system preferences.  The database is configured in
+:mod:`altinet.localnode.settings` using SQLite.
+"""
+
+from django.db import models
+
+
+class User(models.Model):
+    """A minimal user profile."""
+
+    username = models.CharField(max_length=150, unique=True)
+    email = models.EmailField(blank=True)
+
+    def __str__(self) -> str:  # pragma: no cover - human readable representation
+        return self.username
+
+
+class SystemPreference(models.Model):
+    """A key-value preference tied to a :class:`User`."""
+
+    user = models.ForeignKey(User, related_name="preferences", on_delete=models.CASCADE)
+    key = models.CharField(max_length=100)
+    value = models.CharField(max_length=255)
+
+    class Meta:
+        unique_together = ("user", "key")
+
+    def __str__(self) -> str:  # pragma: no cover - human readable representation
+        return f"{self.user}: {self.key}={self.value}"

--- a/src/altinet/altinet/localnode/settings.py
+++ b/src/altinet/altinet/localnode/settings.py
@@ -12,6 +12,8 @@ ALLOWED_HOSTS = ["*"]
 
 INSTALLED_APPS = [
     "django.contrib.staticfiles",
+    "django.contrib.contenttypes",
+    "altinet.localnode",
 ]
 
 MIDDLEWARE = [
@@ -30,3 +32,10 @@ TEMPLATES = [
 ]
 
 STATIC_URL = "/static/"
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "localnode.sqlite3",
+    }
+}

--- a/src/altinet/altinet/localnode/startup.py
+++ b/src/altinet/altinet/localnode/startup.py
@@ -21,4 +21,6 @@ def start_server(host: str = "127.0.0.1", port: int = 8000) -> None:
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "altinet.localnode.settings")
     django.setup()
+    # Ensure the database and tables exist before starting the server
+    call_command("migrate", interactive=False)
     call_command("runserver", f"{host}:{port}")


### PR DESCRIPTION
## Summary
- add Django ORM models for storing users and their key/value system preferences
- configure local node settings with SQLite database and registered app
- ensure startup applies migrations before launching server

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf9ee8ce6c832f915786532d13754d