### PR TITLE
Add basic logging utilities and network node logging

### DIFF
--- a/src/altinet/altinet/core/network.py
+++ b/src/altinet/altinet/core/network.py
@@ -2,6 +2,10 @@
 
 from dataclasses import dataclass
 
+from altinet.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
 
 @dataclass
 class NetworkNode:
@@ -11,4 +15,5 @@ class NetworkNode:
 
     def connect(self, other: "NetworkNode") -> None:
         """Placeholder method to establish a connection to another node."""
+        logger.info("Connecting %s to %s", self.address, other.address)
         raise NotImplementedError

--- a/src/altinet/altinet/utils/__init__.py
+++ b/src/altinet/altinet/utils/__init__.py
@@ -1,3 +1,3 @@
 """Utility helpers for Altinet."""
 
-__all__ = ["crypto"]
+__all__ = ["crypto", "logger"]

--- a/src/altinet/altinet/utils/logger.py
+++ b/src/altinet/altinet/utils/logger.py
@@ -1,0 +1,36 @@
+"""Logging helpers for Altinet.
+
+Provides a ``get_logger`` function that returns a configured logger with a
+standard format. The logger uses a :class:`~logging.StreamHandler` so log output
+is visible on the console by default.
+"""
+
+from __future__ import annotations
+
+import logging
+
+
+def get_logger(name: str) -> logging.Logger:
+    """Return a configured :class:`logging.Logger` instance.
+
+    Parameters
+    ----------
+    name:
+        Name of the logger, typically ``__name__`` of the caller.
+
+    Returns
+    -------
+    logging.Logger
+        Configured logger with a simple console handler attached.
+    """
+    logger = logging.getLogger(name)
+    if not logger.handlers:
+        handler = logging.StreamHandler()
+        formatter = logging.Formatter(
+            "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+        )
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger
+


### PR DESCRIPTION
## Summary
- add reusable `get_logger` helper for consistent logging configuration
- log network node connections using new logger

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c29a8aaa74832f828db150f5515e06