### PR TITLE
feat: add llama.cpp offline llm service

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,5 @@
 Django>=4.2
 opencv-python
 face-recognition
+
+llama-cpp-python

--- a/src/altinet/altinet/services/__init__.py
+++ b/src/altinet/altinet/services/__init__.py
@@ -1,3 +1,3 @@
 """High level services for Altinet."""
 
-__all__ = ["discovery", "messaging", "memory"]
+__all__ = ["discovery", "messaging", "memory", "llm"]

--- a/src/altinet/altinet/services/llm.py
+++ b/src/altinet/altinet/services/llm.py
@@ -1,0 +1,83 @@
+"""Offline LLM service using llama.cpp."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Optional
+
+
+class OfflineLLMService:
+    """Interface to a local LLaMA model via llama.cpp.
+
+    The service loads a model from ``model_path`` using ``llama-cpp-python``.
+    It can be queried with environment descriptions, user preferences and a
+    specific request. The model is expected to return a JSON object describing
+    an action and its arguments.
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        *,
+        llama_client: Optional[Any] = None,
+        n_ctx: int = 2048,
+        temperature: float = 0.2,
+        max_tokens: int = 256,
+    ) -> None:
+        """Create the service.
+
+        Parameters
+        ----------
+        model_path:
+            Path to the LLaMA model weights.
+        llama_client:
+            Optional pre-initialised ``llama_cpp.Llama`` instance. Supplying
+            this allows tests to stub out the heavy model dependency.
+        n_ctx:
+            Context window passed to the underlying model when ``llama_client``
+            is not provided.
+        temperature:
+            Sampling temperature used for generation.
+        max_tokens:
+            Maximum number of tokens to generate.
+        """
+
+        if llama_client is not None:
+            self._llama = llama_client
+        else:  # pragma: no cover - requires the optional dependency
+            from llama_cpp import Llama
+
+            self._llama = Llama(model_path=model_path, n_ctx=n_ctx)
+
+        self._temperature = temperature
+        self._max_tokens = max_tokens
+
+    @staticmethod
+    def build_prompt(environment: str, user_info: str, user_request: str) -> str:
+        """Construct a prompt for the model.
+
+        The prompt includes a summary of the environment, known user
+        preferences and the current request. The model is instructed to respond
+        with a JSON object containing ``action`` and ``arguments`` fields.
+        """
+
+        return (
+            f"Environment:\n{environment}\n\n"
+            f"User preferences:\n{user_info}\n\n"
+            f"User request:\n{user_request}\n\n"
+            "Respond with a JSON object containing an 'action' key and an "
+            "'arguments' object."
+        )
+
+    def choose_action(self, environment: str, user_info: str, user_request: str) -> Dict[str, Any]:
+        """Query the model and return the parsed action description."""
+
+        prompt = self.build_prompt(environment, user_info, user_request)
+        result = self._llama(
+            prompt,
+            max_tokens=self._max_tokens,
+            temperature=self._temperature,
+            stop=["</s>"],
+        )
+        text = result["choices"][0]["text"].strip()
+        return json.loads(text)

--- a/tests/test_llm_service.py
+++ b/tests/test_llm_service.py
@@ -1,0 +1,30 @@
+"""Tests for the offline LLM service."""
+
+from altinet.services.llm import OfflineLLMService
+
+
+class FakeLlama:
+    """Minimal stub of ``llama_cpp.Llama`` for testing."""
+
+    def __init__(self) -> None:
+        self.last_prompt = None
+
+    def __call__(self, prompt: str, *, max_tokens: int, temperature: float, stop: list[str]):
+        self.last_prompt = prompt
+        # Return a deterministic JSON action
+        return {"choices": [{"text": '{"action": "greet", "arguments": {"name": "Bob"}}'}]}
+
+
+def test_build_prompt_includes_sections() -> None:
+    prompt = OfflineLLMService.build_prompt("sunny", "likes tea", "say hello")
+    assert "Environment:" in prompt
+    assert "User preferences:" in prompt
+    assert "User request:" in prompt
+
+
+def test_choose_action_parses_model_output() -> None:
+    fake = FakeLlama()
+    service = OfflineLLMService(model_path="dummy", llama_client=fake)
+    result = service.choose_action("rainy", "prefers coffee", "greet Bob")
+    assert result == {"action": "greet", "arguments": {"name": "Bob"}}
+    assert "Environment:\nrainy" in fake.last_prompt


### PR DESCRIPTION
## Summary
- add OfflineLLMService to interact with local llama.cpp model
- expose new service and dependency
- cover behaviour with lightweight unit tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c2bdf5f680832f946b01ba4db5faf4