### PR TITLE
Configure localnode networking

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,18 @@ ros2 run altinet face_identifier_node
 
 A minimal Django-based GUI is available for running a local Altinet node.
 It now includes a simple map editor for placing nodes around your home and a
-live view that reports basic environmental information.
+live view that reports basic environmental information. On startup the node
+connects to your home Wi-Fi and creates an isolated "Altinet" access point for
+other devices. Provide the necessary network details through environment
+variables before launching the server:
+
+```bash
+export ALTINET_HOME_WIFI_SSID="<home-ssid>"
+export ALTINET_HOME_WIFI_PASSWORD="<home-password>"
+export ALTINET_AP_SSID="Altinet"
+export ALTINET_AP_PASSWORD="altinetpass"
+```
+
 To launch the development server:
 
 ```bash

--- a/src/altinet/altinet/localnode/startup.py
+++ b/src/altinet/altinet/localnode/startup.py
@@ -1,6 +1,79 @@
 """Startup script for the Altinet local node GUI."""
 
 import os
+import subprocess
+
+
+def _configure_network() -> None:
+    """Configure networking for the local node.
+
+    The node first connects to the home Wi-Fi network and then creates a
+    separate access point for Altinet devices. Internet connectivity is
+    blocked on the Altinet network to keep it isolated from the home network.
+    Network credentials and interface names are provided via environment
+    variables:
+
+    ``ALTINET_HOME_WIFI_SSID`` and ``ALTINET_HOME_WIFI_PASSWORD`` define the
+    home network to connect to. ``ALTINET_AP_SSID`` and
+    ``ALTINET_AP_PASSWORD`` set the SSID and passphrase for the Altinet access
+    point. ``ALTINET_HOME_WIFI_IFACE`` and ``ALTINET_AP_IFACE`` optionally
+    specify the wireless interfaces to use (default ``wlan0`` and ``wlan1``
+    respectively).
+
+    This function relies on the presence of ``nmcli`` for network management
+    and ``iptables`` for blocking forwarding between interfaces.
+    """
+
+    home_ssid = os.getenv("ALTINET_HOME_WIFI_SSID")
+    home_password = os.getenv("ALTINET_HOME_WIFI_PASSWORD")
+    ap_ssid = os.getenv("ALTINET_AP_SSID", "Altinet")
+    ap_password = os.getenv("ALTINET_AP_PASSWORD", "altinetpass")
+    home_iface = os.getenv("ALTINET_HOME_WIFI_IFACE", "wlan0")
+    ap_iface = os.getenv("ALTINET_AP_IFACE", "wlan1")
+
+    if not home_ssid or not home_password:
+        raise RuntimeError(
+            "Home WiFi credentials must be provided via environment variables"
+        )
+
+    # Connect to the home Wi-Fi network
+    subprocess.run(
+        [
+            "nmcli",
+            "dev",
+            "wifi",
+            "connect",
+            home_ssid,
+            "password",
+            home_password,
+            "ifname",
+            home_iface,
+        ],
+        check=True,
+    )
+
+    # Create an access point for Altinet devices
+    subprocess.run(
+        [
+            "nmcli",
+            "dev",
+            "wifi",
+            "hotspot",
+            "ifname",
+            ap_iface,
+            "ssid",
+            ap_ssid,
+            "password",
+            ap_password,
+        ],
+        check=True,
+    )
+
+    # Prevent forwarding between the Altinet AP and the home network
+    subprocess.run(
+        ["iptables", "-I", "FORWARD", "-i", ap_iface, "-j", "DROP"],
+        check=True,
+    )
 
 
 def start_server(host: str = "127.0.0.1", port: int = 8000) -> None:
@@ -18,6 +91,8 @@ def start_server(host: str = "127.0.0.1", port: int = 8000) -> None:
         import django
     except ModuleNotFoundError as exc:  # pragma: no cover - runtime dependency
         raise RuntimeError("Django must be installed to run the local node GUI") from exc
+
+    _configure_network()
 
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "altinet.localnode.settings")
     django.setup()


### PR DESCRIPTION
## Summary
- connect to home Wi-Fi and create isolated Altinet access point during local node startup
- document required environment variables for configuring networking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c39261b87c832faeca36d43c3ac671