### PR TITLE
Add network console command for managing Wi-Fi connections

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,12 @@ To launch the development server:
 python -m altinet.localnode.startup
 ```
 
+To view and manage Wi-Fi connections directly, a simple network console can be
+launched with:
+
+```bash
+python -m altinet.core.network
+```
+
 By default the server binds to `127.0.0.1:8000`. You can override the host
 and port by passing arguments to `start_server`.

--- a/src/altinet/altinet/core/network.py
+++ b/src/altinet/altinet/core/network.py
@@ -1,6 +1,7 @@
 """Networking primitives for Altinet."""
 
 from dataclasses import dataclass
+import subprocess
 
 from altinet.utils.logger import get_logger
 
@@ -17,3 +18,25 @@ class NetworkNode:
         """Placeholder method to establish a connection to another node."""
         logger.info("Connecting %s to %s", self.address, other.address)
         raise NotImplementedError
+
+
+def open_network_console() -> None:
+    """Launch the system network console for managing Wi-Fi connections.
+
+    This function attempts to start the ``nmtui`` program, providing a text
+    user interface for viewing and controlling NetworkManager connections. A
+    ``RuntimeError`` is raised if ``nmtui`` is not available or fails to run.
+    """
+
+    try:
+        subprocess.run(["nmtui"], check=True)
+    except FileNotFoundError as exc:  # pragma: no cover - external dependency
+        raise RuntimeError(
+            "nmtui command not found; ensure NetworkManager's text UI is installed"
+        ) from exc
+    except subprocess.CalledProcessError as exc:  # pragma: no cover - runtime
+        raise RuntimeError("Failed to launch network console") from exc
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI behaviour
+    open_network_console()


### PR DESCRIPTION
## Summary
- add `open_network_console` function launching `nmtui`
- document network console usage in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3d8a9ba24832f8a21e4831f58510e