### PR TITLE
Add time-based confidence check to face detector node

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,7 +32,7 @@ altinet/
 - **nodes**: ROS 2 nodes that expose Altinet functionality at runtime.
   - `minimal_node`: placeholder node that logs a startup message.
   - `camera_node`: publishes images from a camera device.
-  - `face_detector_node`: detects faces and publishes bounding boxes.
+  - `face_detector_node`: detects faces and publishes bounding boxes after a time-based confidence check.
   - `face_identifier_node`: attempts to match faces against known identities.
 - **tests**: Unit tests that exercise the behavior of the system.
 


### PR DESCRIPTION
## Summary
- track how long faces persist in `face_detector_node`
- publish bounding boxes only after a face is present for a minimum duration
- document the time-based confidence check in architecture docs

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c3e54d1dec832facdac4333655819f