### PR TITLE
Automatically train facial recognition for new users

### DIFF
--- a/scripts/add_user.py
+++ b/scripts/add_user.py
@@ -6,10 +6,17 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
-try:  # pragma: no cover - optional dependency
+from altinet.services.face_recognition import FaceRecognitionService
+
+try:  # pragma: no cover - optional dependencies
     import cv2  # type: ignore
 except ImportError:  # pragma: no cover - dependency might be missing
     cv2 = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    import face_recognition  # type: ignore
+except ImportError:  # pragma: no cover - dependency might be missing
+    face_recognition = None  # type: ignore
 
 
 def collect_user_data() -> Dict[str, Any]:
@@ -56,6 +63,26 @@ def capture_photos(out_dir: Path, count: int) -> None:
     cap.release()
 
 
+def train_user_photos(user_dir: Path, name: str) -> None:
+    """Train the face recognition system on images in ``user_dir``.
+
+    Each photo in ``user_dir / 'photos'`` is encoded and added to the
+    :class:`~altinet.services.face_recognition.FaceRecognitionService` cache as
+    ``name``.  If the ``face_recognition`` dependency is unavailable, a message
+    is printed and the function returns silently.
+    """
+    if face_recognition is None:  # pragma: no cover - dependency missing
+        print("face_recognition is not installed; skipping training.")
+        return
+    service = FaceRecognitionService()
+    photos_dir = user_dir / "photos"
+    if not photos_dir.exists():
+        return
+    for photo in photos_dir.glob("*.jpg"):
+        image = face_recognition.load_image_file(photo)
+        service.train(image, name)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(
         description="Add a user and capture training photos."
@@ -84,6 +111,8 @@ def main() -> None:
     with (user_dir / "metadata.json").open("w", encoding="utf-8") as fh:
         json.dump(data, fh, indent=2)
     print(f"User data saved to {user_dir}")
+
+    train_user_photos(user_dir, data["name"])
 
 
 if __name__ == "__main__":

--- a/src/altinet/altinet/services/face_recognition.py
+++ b/src/altinet/altinet/services/face_recognition.py
@@ -33,6 +33,23 @@ class FaceRecognitionService:
         self._known_identities: List[str] = []
         self._known_confidences: List[float] = []
 
+    def train(self, image: Any, identity: str, confidence: float = 1.0) -> None:
+        """Add ``image`` to the cache as ``identity``.
+
+        The image is encoded using the configured ``encoder`` and stored with
+        the provided identity and confidence. If the encoder is unavailable or
+        no encodings are produced, the call is ignored.
+        """
+        if self._encoder is None:
+            return
+        encodings = self._encoder.face_encodings(image)
+        if not encodings:
+            return
+        encoding = encodings[0]
+        self._known_encodings.append(encoding)
+        self._known_identities.append(identity)
+        self._known_confidences.append(confidence)
+
     def recognize(self, image: Any) -> Tuple[str, float]:
         """Return the identity and confidence for ``image``.
 

--- a/tests/test_add_user_script.py
+++ b/tests/test_add_user_script.py
@@ -23,3 +23,9 @@ def test_capture_photos_without_cv2(monkeypatch, tmp_path, capsys):
     add_user.capture_photos(tmp_path, 3)
     assert not list(tmp_path.iterdir())
     assert "OpenCV is not installed" in capsys.readouterr().out
+
+
+def test_train_user_photos_without_face_recognition(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(add_user, "face_recognition", None)
+    add_user.train_user_photos(tmp_path, "Alice")
+    assert "face_recognition is not installed" in capsys.readouterr().out

--- a/tests/test_face_recognition_service.py
+++ b/tests/test_face_recognition_service.py
@@ -36,3 +36,10 @@ def test_identifier_called_only_for_unknown_faces() -> None:
     second = service.recognize("face1")
     assert second == ("Alice", 0.9)
     assert backend.calls == 1
+
+
+def test_training_adds_known_identity() -> None:
+    service = FaceRecognitionService(encoder=FakeEncoder())
+    service.train("face2", "Bob", 0.8)
+    result = service.recognize("face2")
+    assert result == ("Bob", 0.8)


### PR DESCRIPTION
## Summary
- add `train` helper to `FaceRecognitionService` for caching known faces
- allow `add_user` script to train face recognition from captured photos
- test training workflow and missing dependency behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3f78253e4832fac97705a8753700e