### PR TITLE
Include subpackages in ROS package install

### DIFF
--- a/src/altinet/setup.py
+++ b/src/altinet/setup.py
@@ -1,11 +1,11 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 package_name = 'altinet'
 
 setup(
     name=package_name,
     version='0.1.0',
-    packages=[package_name],
+    packages=find_packages(),
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml'])


### PR DESCRIPTION
## Summary
- ensure `setup.py` installs all nested packages so node entrypoints are available

## Testing
- `pytest`
- ⚠️ `colcon build` (missing `colcon`; attempted to install but repo access was forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68c40d2b6400832fb188a63b3ab66e32