### PR TITLE
Include subpackages in ROS package install

### DIFF
--- a/src/altinet/setup.cfg
+++ b/src/altinet/setup.cfg
@@ -1,4 +1,4 @@
 [develop]
-script-dir=$base/lib/altinet
+script_dir=$base/lib/altinet
 [install]
-install-scripts=$base/lib/altinet
+install_scripts=$base/lib/altinet

--- a/src/altinet/setup.py
+++ b/src/altinet/setup.py
@@ -1,11 +1,11 @@
-from setuptools import setup
+from setuptools import setup, find_packages
 
 package_name = 'altinet'
 
 setup(
     name=package_name,
     version='0.1.0',
-    packages=[package_name],
+    packages=find_packages(),
     data_files=[
         ('share/ament_index/resource_index/packages', ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml'])
@@ -23,8 +23,7 @@ setup(
             'minimal_node = altinet.nodes.minimal_node:main',
             'camera_node = altinet.nodes.camera_node:main',
             'face_detector_node = altinet.nodes.face_detector_node:main',
-            'face_identifier_node = altinet.nodes.face_identifier_node:main',
-            'minimal_node = altinet.nodes.minimal_node:main'
+            'face_identifier_node = altinet.nodes.face_identifier_node:main'
 
         ],
     },


### PR DESCRIPTION
## Summary
- ensure setup uses underscore options so entry-point scripts install under `lib/altinet`
- remove duplicate console script entry so nodes register correctly

## Testing
- `pytest`
- ⚠️ `colcon build --symlink-install` (missing `colcon`; pip install blocked by proxy)


------
https://chatgpt.com/codex/tasks/task_e_68c40d2b6400832fb188a63b3ab66e32