### PR TITLE
Convert altinet package to ament_python

### DIFF
--- a/src/altinet/CMakeLists.txt
+++ b/src/altinet/CMakeLists.txt
@@ -1,9 +1,0 @@
-cmake_minimum_required(VERSION 3.5)
-project(altinet)
-
-find_package(ament_cmake REQUIRED)
-find_package(ament_cmake_python REQUIRED)
-
-ament_python_install_package(${PROJECT_NAME})
-
-ament_package()

--- a/src/altinet/package.xml
+++ b/src/altinet/package.xml
@@ -6,8 +6,7 @@
   <maintainer email="maintainer@example.com">Altinet Maintainer</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
-  <buildtool_depend>ament_cmake_python</buildtool_depend>
+  <buildtool_depend>ament_python</buildtool_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
@@ -15,7 +14,7 @@
   <exec_depend>cv_bridge</exec_depend>
 
   <export>
-    <build_type>ament_cmake</build_type>
+    <build_type>ament_python</build_type>
   </export>
 
 </package>


### PR DESCRIPTION
## Summary
- switch `package.xml` to `ament_python` build tool and export
- drop CMakeLists.txt for a pure Python package

## Testing
- `colcon build --symlink-install` *(fails: command not found)*
- `source install/setup.bash` *(fails: No such file or directory)*
- `ros2 pkg executables altinet` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c416fe7fa0832fb0d02f6bfe40c725