### PR TITLE
Add camera viewer node and tests

### DIFF
--- a/src/altinet/altinet/nodes/camera_viewer_node.py
+++ b/src/altinet/altinet/nodes/camera_viewer_node.py
@@ -1,0 +1,56 @@
+import rclpy
+from rclpy.node import Node
+from sensor_msgs.msg import Image
+
+try:
+    from cv_bridge import CvBridge
+except ImportError:  # pragma: no cover - dependency might be missing
+    CvBridge = None  # type: ignore
+
+try:
+    import cv2
+except ImportError:  # pragma: no cover - dependency might be missing
+    cv2 = None  # type: ignore
+
+
+class CameraViewerNode(Node):
+    """Display images from the camera node in a window."""
+
+    def __init__(self) -> None:
+        super().__init__("camera_viewer_node")
+        self.subscription = self.create_subscription(
+            Image, "camera/image", self.listener_callback, 10
+        )
+        self.bridge = CvBridge() if CvBridge and cv2 else None
+        if not cv2 or not self.bridge:
+            self.get_logger().warning("OpenCV not available; live view disabled")
+        else:  # pragma: no cover - GUI interaction
+            cv2.namedWindow("Camera")
+
+    def listener_callback(self, msg: Image) -> None:  # pragma: no cover - requires GUI
+        if not self.bridge or not cv2:
+            return
+        frame = self.bridge.imgmsg_to_cv2(msg, desired_encoding="bgr8")
+        cv2.imshow("Camera", frame)
+        cv2.waitKey(1)
+
+    def destroy_node(self) -> None:  # pragma: no cover - resource cleanup
+        if cv2:
+            cv2.destroyAllWindows()
+        super().destroy_node()
+
+
+def main(args=None) -> None:
+    rclpy.init(args=args)
+    node = CameraViewerNode()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/altinet/setup.py
+++ b/src/altinet/setup.py
@@ -22,6 +22,7 @@ setup(
 
             'minimal_node = altinet.nodes.minimal_node:main',
             'camera_node = altinet.nodes.camera_node:main',
+            'camera_viewer_node = altinet.nodes.camera_viewer_node:main',
             'face_detector_node = altinet.nodes.face_detector_node:main',
             'face_identifier_node = altinet.nodes.face_identifier_node:main'
 

--- a/tests/test_camera_viewer_node.py
+++ b/tests/test_camera_viewer_node.py
@@ -1,0 +1,58 @@
+"""Tests for the camera viewer node."""
+
+from types import ModuleType
+import importlib
+import sys
+import builtins
+
+
+def test_initialization_without_cv2(monkeypatch) -> None:
+    """Node should initialize even when ``cv2`` is missing."""
+
+    # Stub required ROS message modules
+    sensor_msgs = ModuleType("sensor_msgs")
+    sensor_msgs.msg = ModuleType("sensor_msgs.msg")
+    sensor_msgs.msg.Image = object
+    monkeypatch.setitem(sys.modules, "sensor_msgs", sensor_msgs)
+    monkeypatch.setitem(sys.modules, "sensor_msgs.msg", sensor_msgs.msg)
+
+    # Minimal rclpy Node stub
+    class DummyNode:
+        def __init__(self, name):
+            self.name = name
+
+        def create_subscription(self, *args, **kwargs):
+            pass
+
+        class Logger:
+            def warning(self, *args, **kwargs):
+                pass
+
+        def get_logger(self):  # pragma: no cover - trivial
+            return self.Logger()
+
+    rclpy = ModuleType("rclpy")
+    rclpy.node = ModuleType("rclpy.node")
+    rclpy.node.Node = DummyNode
+    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
+    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
+
+    # Dummy cv_bridge module
+    cv_bridge = ModuleType("cv_bridge")
+    class DummyBridge:
+        def imgmsg_to_cv2(self, msg, desired_encoding="bgr8"):
+            return msg
+    cv_bridge.CvBridge = DummyBridge
+    monkeypatch.setitem(sys.modules, "cv_bridge", cv_bridge)
+
+    # Force ImportError for cv2
+    orig_import = builtins.__import__
+    def fake_import(name, *args, **kwargs):
+        if name == "cv2":
+            raise ImportError
+        return orig_import(name, *args, **kwargs)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+
+    camera_viewer_node = importlib.import_module("altinet.nodes.camera_viewer_node")
+    node = camera_viewer_node.CameraViewerNode()
+    assert node.bridge is None


### PR DESCRIPTION
## Summary
- add a node to display images from the camera topic using OpenCV
- expose the node via console script entry point
- cover camera viewer initialization when cv2 is missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c43257dfc0832fb644152c47d7103d