### PR TITLE
Allow custom cascade when cv2 data missing

### DIFF
--- a/src/altinet/altinet/nodes/face_detector_node.py
+++ b/src/altinet/altinet/nodes/face_detector_node.py
@@ -29,18 +29,24 @@ class FaceDetectorNode(Node):
         self.publisher = self.create_publisher(Int32MultiArray, "faces", 10)
         self.bridge = CvBridge() if CvBridge and cv2 else None
         if cv2:
+            # Declare parameter before checking cv2.data so a user-provided path
+            # can be used even when OpenCV lacks bundled cascade files.
+            cascade_param = self.declare_parameter("cascade_path", "").value
+            xml_path = Path(cascade_param) if cascade_param else None
             data = getattr(cv2, "data", None)
             if data is None:
-                self.get_logger().warning(
-                    "cv2.data not available; provide cascade_path parameter"
-                )
-                self.face_cascade = None
+                if xml_path and xml_path.exists():
+                    self.face_cascade = cv2.CascadeClassifier(str(xml_path))
+                else:
+                    self.get_logger().warning(
+                        "cv2.data not available; provide cascade_path parameter"
+                    )
+                    self.face_cascade = None
             else:
                 cascade_dir = Path(getattr(data, "haarcascades", data))
-                xml_path = cascade_dir / "haarcascade_frontalface_default.xml"
-                xml_path = Path(
-                    self.declare_parameter("cascade_path", str(xml_path)).value
-                )
+                default_xml = cascade_dir / "haarcascade_frontalface_default.xml"
+                if xml_path is None:
+                    xml_path = default_xml
                 if xml_path.exists():
                     self.face_cascade = cv2.CascadeClassifier(str(xml_path))
                 else:

--- a/tests/test_face_detector_node.py
+++ b/tests/test_face_detector_node.py
@@ -1,4 +1,5 @@
 """Tests for the face detector node."""
+"""Tests for the face detector node."""
 
 from types import ModuleType
 import importlib
@@ -74,6 +75,152 @@ def test_initialization_without_cascade_file(monkeypatch, tmp_path) -> None:
     cv2.data.haarcascades = str(tmp_path / "does_not_exist")
     monkeypatch.setitem(sys.modules, "cv2", cv2)
 
+    face_detector_node = importlib.import_module("altinet.nodes.face_detector_node")
+
+    node = face_detector_node.FaceDetectorNode()
+    assert node.face_cascade is None
+
+
+def test_initialization_with_cv2_data_missing_and_valid_path(monkeypatch, tmp_path) -> None:
+    """Loads classifier from provided path when cv2 lacks bundled data."""
+
+    sensor_msgs = ModuleType("sensor_msgs")
+    sensor_msgs.msg = ModuleType("sensor_msgs.msg")
+    sensor_msgs.msg.Image = object
+    monkeypatch.setitem(sys.modules, "sensor_msgs", sensor_msgs)
+    monkeypatch.setitem(sys.modules, "sensor_msgs.msg", sensor_msgs.msg)
+
+    std_msgs = ModuleType("std_msgs")
+    std_msgs.msg = ModuleType("std_msgs.msg")
+    std_msgs.msg.Int32MultiArray = object
+    monkeypatch.setitem(sys.modules, "std_msgs", std_msgs)
+    monkeypatch.setitem(sys.modules, "std_msgs.msg", std_msgs.msg)
+
+    class DummyNode:
+        parameters = {}
+
+        def __init__(self, name):
+            self.name = name
+
+        def create_subscription(self, *args, **kwargs):
+            pass
+
+        def create_publisher(self, *args, **kwargs):
+            pass
+
+        class Logger:
+            def warning(self, *args, **kwargs):
+                pass
+
+            def info(self, *args, **kwargs):
+                pass
+
+        def get_logger(self):
+            return self.Logger()
+
+        def declare_parameter(self, name, default):
+            class Param:
+                def __init__(self, value):
+                    self.value = value
+
+            return Param(self.parameters.get(name, default))
+
+    # Provide path to existing cascade file
+    xml_file = tmp_path / "cascade.xml"
+    xml_file.write_text("test")
+    DummyNode.parameters = {"cascade_path": str(xml_file)}
+
+    rclpy = ModuleType("rclpy")
+    rclpy.node = ModuleType("rclpy.node")
+    rclpy.node.Node = DummyNode
+    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
+    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
+
+    cv2 = ModuleType("cv2")
+
+    class DummyCascade:
+        def __init__(self, xml_path):
+            self.xml_path = xml_path
+
+        def detectMultiScale(self, *args, **kwargs):
+            return []
+
+    cv2.CascadeClassifier = DummyCascade
+    cv2.data = None
+    monkeypatch.setitem(sys.modules, "cv2", cv2)
+
+    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
+    face_detector_node = importlib.import_module("altinet.nodes.face_detector_node")
+
+    node = face_detector_node.FaceDetectorNode()
+    assert isinstance(node.face_cascade, DummyCascade)
+    assert node.face_cascade.xml_path == str(xml_file)
+
+
+def test_initialization_with_cv2_data_missing_and_no_path(monkeypatch, tmp_path) -> None:
+    """When cv2.data is missing and no path provided, detection disabled."""
+
+    sensor_msgs = ModuleType("sensor_msgs")
+    sensor_msgs.msg = ModuleType("sensor_msgs.msg")
+    sensor_msgs.msg.Image = object
+    monkeypatch.setitem(sys.modules, "sensor_msgs", sensor_msgs)
+    monkeypatch.setitem(sys.modules, "sensor_msgs.msg", sensor_msgs.msg)
+
+    std_msgs = ModuleType("std_msgs")
+    std_msgs.msg = ModuleType("std_msgs.msg")
+    std_msgs.msg.Int32MultiArray = object
+    monkeypatch.setitem(sys.modules, "std_msgs", std_msgs)
+    monkeypatch.setitem(sys.modules, "std_msgs.msg", std_msgs.msg)
+
+    class DummyNode:
+        parameters = {}
+
+        def __init__(self, name):
+            self.name = name
+
+        def create_subscription(self, *args, **kwargs):
+            pass
+
+        def create_publisher(self, *args, **kwargs):
+            pass
+
+        class Logger:
+            def warning(self, *args, **kwargs):
+                pass
+
+            def info(self, *args, **kwargs):
+                pass
+
+        def get_logger(self):
+            return self.Logger()
+
+        def declare_parameter(self, name, default):
+            class Param:
+                def __init__(self, value):
+                    self.value = value
+
+            return Param(self.parameters.get(name, default))
+
+    rclpy = ModuleType("rclpy")
+    rclpy.node = ModuleType("rclpy.node")
+    rclpy.node.Node = DummyNode
+    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
+    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
+
+    cv2 = ModuleType("cv2")
+
+    class DummyCascade:
+        def __init__(self, xml_path):
+            self.xml_path = xml_path
+
+        def detectMultiScale(self, *args, **kwargs):
+            return []
+
+    cv2.CascadeClassifier = DummyCascade
+    cv2.data = None
+    monkeypatch.setitem(sys.modules, "cv2", cv2)
+
+    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
     face_detector_node = importlib.import_module("altinet.nodes.face_detector_node")
 
     node = face_detector_node.FaceDetectorNode()


### PR DESCRIPTION
## Summary
- declare `cascade_path` parameter before checking OpenCV data
- load cascade from user-provided path when `cv2.data` is absent
- add tests for custom cascade path and missing path scenarios

## Testing
- `pytest tests/test_face_detector_node.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4449e22a8832fbb5dc81109afe6d9