### PR TITLE
Improve face detection cascade handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,13 @@ ros2 run altinet face_identifier_node
 ```
 
 OpenCV Haar cascade XML files for face and eye detection are available in
-`assets/haarcascades`. Use the `cascade_path` parameter with
-`face_detector_node` if your OpenCV build does not include these files.
+`assets/haarcascades`. If your OpenCV build does not include these files,
+pass their location to `face_detector_node`:
+
+```bash
+ros2 run altinet face_detector_node --ros-args -p \
+  cascade_path:=assets/haarcascades/haarcascade_frontalface_default.xml
+```
 
 
 

--- a/tests/test_face_detector_node.py
+++ b/tests/test_face_detector_node.py
@@ -1,12 +1,11 @@
 """Tests for the face detector node."""
-"""Tests for the face detector node."""
 
 from types import ModuleType
 import importlib
 import sys
 
 
-def _stub_ros_modules(monkeypatch):
+def _stub_ros(monkeypatch, parameters=None):
     sensor_msgs = ModuleType("sensor_msgs")
     sensor_msgs.msg = ModuleType("sensor_msgs.msg")
     sensor_msgs.msg.Image = object
@@ -19,395 +18,171 @@ def _stub_ros_modules(monkeypatch):
     monkeypatch.setitem(sys.modules, "std_msgs", std_msgs)
     monkeypatch.setitem(sys.modules, "std_msgs.msg", std_msgs.msg)
 
+    class DummyNode:
+        params = parameters or {}
+
+        def __init__(self, name):
+            self.name = name
+            self._logger = self.Logger()
+
+        def create_subscription(self, *args, **kwargs):
+            pass
+
+        def create_publisher(self, *args, **kwargs):
+            pass
+
+        class Logger:
+            def __init__(self):
+                self.infos = []
+                self.warnings = []
+
+            def warning(self, msg, *args, **kwargs):
+                self.warnings.append(msg)
+
+            def info(self, msg, *args, **kwargs):
+                self.infos.append(msg)
+
+        def get_logger(self):
+            return self._logger
+
+        def declare_parameter(self, name, default):
+            class Param:
+                def __init__(self, value):
+                    self.value = value
+
+            return Param(self.params.get(name, default))
+
+    rclpy = ModuleType("rclpy")
+    rclpy.node = ModuleType("rclpy.node")
+    rclpy.node.Node = DummyNode
+    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
+    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
 
 
-def test_face_detector_subscribes_to_camera_topic(monkeypatch) -> None:
+def test_listener_callback_logs_once(monkeypatch):
+    """Disabled face detection should log only once."""
+
+    _stub_ros(monkeypatch)
+
+    # stub cv2 and cv_bridge
+    cv2 = ModuleType("cv2")
+    cv2.data = None
+    cv2.CascadeClassifier = lambda path: None
+    monkeypatch.setitem(sys.modules, "cv2", cv2)
+
+    cv_bridge = ModuleType("cv_bridge")
+    class Bridge:
+        pass
+    cv_bridge.CvBridge = Bridge
+    monkeypatch.setitem(sys.modules, "cv_bridge", cv_bridge)
+
+    # import module
+    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
+    face_module = importlib.import_module("altinet.nodes.face_detector_node")
+
+    node = face_module.FaceDetectorNode()
+    node.face_cascade = None  # ensure disabled
+    msg = object()
+    logger = node.get_logger()
+
+    node.listener_callback(msg)
+    node.listener_callback(msg)
+
+    assert logger.infos.count("Received image frame but face detection is disabled") == 1
+
+
+def test_initialization_uses_repo_cascade(monkeypatch):
+    """Falls back to repo cascade when cv2.data missing."""
+
+    _stub_ros(monkeypatch)
+
+    cv2 = ModuleType("cv2")
+    cv2.data = None
+    class DummyCascade:
+        def __init__(self, xml_path):
+            self.xml_path = xml_path
+    cv2.CascadeClassifier = DummyCascade
+    monkeypatch.setitem(sys.modules, "cv2", cv2)
+
+    cv_bridge = ModuleType("cv_bridge")
+    cv_bridge.CvBridge = object
+    monkeypatch.setitem(sys.modules, "cv_bridge", cv_bridge)
+
+    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
+    face_module = importlib.import_module("altinet.nodes.face_detector_node")
+
+    node = face_module.FaceDetectorNode()
+    assert isinstance(node.face_cascade, DummyCascade)
+    assert node.face_cascade.xml_path == str(face_module.REPO_CASCADE)
+
+
+def test_initialization_without_any_cascade(monkeypatch, tmp_path):
+    """Disables detection when no cascade files are available."""
+
+    _stub_ros(monkeypatch)
+
+    cv2 = ModuleType("cv2")
+    cv2.data = None
+    cv2.CascadeClassifier = lambda path: None
+    monkeypatch.setitem(sys.modules, "cv2", cv2)
+
+    cv_bridge = ModuleType("cv_bridge")
+    cv_bridge.CvBridge = object
+    monkeypatch.setitem(sys.modules, "cv_bridge", cv_bridge)
+
+    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
+    face_module = importlib.import_module("altinet.nodes.face_detector_node")
+    monkeypatch.setattr(face_module, "REPO_CASCADE", tmp_path / "missing.xml")
+
+    node = face_module.FaceDetectorNode()
+    assert node.face_cascade is None
+
+
+def test_face_detector_subscribes_to_camera_topic(monkeypatch):
     """Face detector should listen on the camera image topic."""
 
-    _stub_ros_modules(monkeypatch)
+    recorded = {}
 
-    captured = {}
-
-    class DummyNode:
-        def __init__(self, name):
-            pass
-
-        def create_subscription(self, msg, topic, callback, qos):
-            captured["topic"] = topic
-
-        def create_publisher(self, *args, **kwargs):
-            pass
-
-        class Logger:
-            def warning(self, *args, **kwargs):
+    def custom_stub(monkeypatch):
+        _stub_ros(monkeypatch)
+        class DummyNode:  # override to capture topic
+            params = {}
+            def __init__(self, name):
                 pass
-
-            def info(self, *args, **kwargs):
+            def create_subscription(self, msg, topic, callback, qos):
+                recorded["topic"] = topic
+            def create_publisher(self, *a, **k):
                 pass
+            class Logger:
+                def warning(self, *a, **k):
+                    pass
+                def info(self, *a, **k):
+                    pass
+            def get_logger(self):
+                return self.Logger()
+            def declare_parameter(self, name, default):
+                class Param:
+                    def __init__(self, value):
+                        self.value = value
+                return Param(default)
+        rclpy = ModuleType("rclpy")
+        rclpy.node = ModuleType("rclpy.node")
+        rclpy.node.Node = DummyNode
+        monkeypatch.setitem(sys.modules, "rclpy", rclpy)
+        monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
 
-        def get_logger(self):  # pragma: no cover - trivial
-            return self.Logger()
+    custom_stub(monkeypatch)
 
-        def declare_parameter(self, name, default):
-            class Param:
-                def __init__(self, value):
-                    self.value = value
-
-            return Param(default)
-
-    rclpy = ModuleType("rclpy")
-    rclpy.node = ModuleType("rclpy.node")
-    rclpy.node.Node = DummyNode
-    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
-    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
-
-    # cv2 not available to skip cascade loading
-    monkeypatch.setitem(sys.modules, "cv2", None)
+    cv2 = ModuleType("cv2")
+    cv2.data = None
+    cv2.CascadeClassifier = lambda path: None
+    monkeypatch.setitem(sys.modules, "cv2", cv2)
+    cv_bridge = ModuleType("cv_bridge")
+    cv_bridge.CvBridge = object
+    monkeypatch.setitem(sys.modules, "cv_bridge", cv_bridge)
 
     monkeypatch.delitem(sys.modules, "altinet.nodes.camera_node", raising=False)
     monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
-    face_detector_node = importlib.import_module("altinet.nodes.face_detector_node")
-
-    face_detector_node.FaceDetectorNode()
-    assert captured["topic"] == face_detector_node.IMAGE_TOPIC
-
-
-def test_initialization_without_cascade_file(monkeypatch, tmp_path) -> None:
-    """Node should initialize even when the cascade XML is missing."""
-
-    _stub_ros_modules(monkeypatch)
-
-    # Minimal rclpy Node stub
-    class DummyNode:
-        def __init__(self, name):
-            self.name = name
-
-        def create_subscription(self, *args, **kwargs):
-            pass
-
-        def create_publisher(self, *args, **kwargs):
-            pass
-
-        class Logger:
-            def warning(self, *args, **kwargs):
-                pass
-
-            def info(self, *args, **kwargs):
-                pass
-
-        def get_logger(self):  # pragma: no cover - trivial
-            return self.Logger()
-
-        def declare_parameter(self, name, default):
-            class Param:
-                def __init__(self, value):
-                    self.value = value
-
-            return Param(default)
-
-    rclpy = ModuleType("rclpy")
-    rclpy.node = ModuleType("rclpy.node")
-    rclpy.node.Node = DummyNode
-    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
-    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
-
-    # Dummy cv2 with ``data`` attribute pointing to non-existent cascades
-    cv2 = ModuleType("cv2")
-
-    class DummyCascade:
-        def __init__(self, xml_path):
-            self.xml_path = xml_path
-
-        def detectMultiScale(self, *args, **kwargs):  # pragma: no cover - unused
-            return []
-
-    cv2.CascadeClassifier = DummyCascade
-
-    class Data:
-        pass
-
-    cv2.data = Data()
-    cv2.data.haarcascades = str(tmp_path / "does_not_exist")
-    monkeypatch.setitem(sys.modules, "cv2", cv2)
-
-    monkeypatch.delitem(sys.modules, "altinet.nodes.camera_node", raising=False)
-    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
-    face_detector_node = importlib.import_module("altinet.nodes.face_detector_node")
-
-    node = face_detector_node.FaceDetectorNode()
-    assert node.face_cascade is None
-
-
-def test_initialization_with_cv2_data_missing_and_valid_path(monkeypatch, tmp_path) -> None:
-    """Loads classifier from provided path when cv2 lacks bundled data."""
-
-    _stub_ros_modules(monkeypatch)
-
-    class DummyNode:
-        parameters = {}
-
-        def __init__(self, name):
-            self.name = name
-
-        def create_subscription(self, *args, **kwargs):
-            pass
-
-        def create_publisher(self, *args, **kwargs):
-            pass
-
-        class Logger:
-            def warning(self, *args, **kwargs):
-                pass
-
-            def info(self, *args, **kwargs):
-                pass
-
-        def get_logger(self):
-            return self.Logger()
-
-        def declare_parameter(self, name, default):
-            class Param:
-                def __init__(self, value):
-                    self.value = value
-
-            return Param(self.parameters.get(name, default))
-
-    # Provide path to existing cascade file
-    xml_file = tmp_path / "cascade.xml"
-    xml_file.write_text("test")
-    DummyNode.parameters = {"cascade_path": str(xml_file)}
-
-    rclpy = ModuleType("rclpy")
-    rclpy.node = ModuleType("rclpy.node")
-    rclpy.node.Node = DummyNode
-    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
-    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
-
-    cv2 = ModuleType("cv2")
-
-    class DummyCascade:
-        def __init__(self, xml_path):
-            self.xml_path = xml_path
-
-        def detectMultiScale(self, *args, **kwargs):
-            return []
-
-    cv2.CascadeClassifier = DummyCascade
-    cv2.data = None
-    monkeypatch.setitem(sys.modules, "cv2", cv2)
-
-    monkeypatch.delitem(sys.modules, "altinet.nodes.camera_node", raising=False)
-    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
-    face_detector_node = importlib.import_module("altinet.nodes.face_detector_node")
-
-    node = face_detector_node.FaceDetectorNode()
-    assert isinstance(node.face_cascade, DummyCascade)
-    assert node.face_cascade.xml_path == str(xml_file)
-
-
-def test_initialization_with_cv2_data_missing_and_no_path(monkeypatch, tmp_path) -> None:
-    """When cv2.data is missing and no path provided, detection disabled."""
-
-    _stub_ros_modules(monkeypatch)
-
-    class DummyNode:
-        parameters = {}
-
-        def __init__(self, name):
-            self.name = name
-
-        def create_subscription(self, *args, **kwargs):
-            pass
-
-        def create_publisher(self, *args, **kwargs):
-            pass
-
-        class Logger:
-            def warning(self, *args, **kwargs):
-                pass
-
-            def info(self, *args, **kwargs):
-                pass
-
-        def get_logger(self):
-            return self.Logger()
-
-        def declare_parameter(self, name, default):
-            class Param:
-                def __init__(self, value):
-                    self.value = value
-
-            return Param(self.parameters.get(name, default))
-
-    rclpy = ModuleType("rclpy")
-    rclpy.node = ModuleType("rclpy.node")
-    rclpy.node.Node = DummyNode
-    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
-    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
-
-    cv2 = ModuleType("cv2")
-
-    class DummyCascade:
-        def __init__(self, xml_path):
-            self.xml_path = xml_path
-
-        def detectMultiScale(self, *args, **kwargs):
-            return []
-
-    cv2.CascadeClassifier = DummyCascade
-    cv2.data = None
-    monkeypatch.setitem(sys.modules, "cv2", cv2)
-
-    monkeypatch.delitem(sys.modules, "altinet.nodes.camera_node", raising=False)
-    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
-    face_detector_node = importlib.import_module("altinet.nodes.face_detector_node")
-
-    node = face_detector_node.FaceDetectorNode()
-    assert node.face_cascade is None
-
-
-def test_initialization_with_cv2_data_missing_and_valid_path(monkeypatch, tmp_path) -> None:
-    """Loads classifier from provided path when cv2 lacks bundled data."""
-
-    sensor_msgs = ModuleType("sensor_msgs")
-    sensor_msgs.msg = ModuleType("sensor_msgs.msg")
-    sensor_msgs.msg.Image = object
-    monkeypatch.setitem(sys.modules, "sensor_msgs", sensor_msgs)
-    monkeypatch.setitem(sys.modules, "sensor_msgs.msg", sensor_msgs.msg)
-
-    std_msgs = ModuleType("std_msgs")
-    std_msgs.msg = ModuleType("std_msgs.msg")
-    std_msgs.msg.Int32MultiArray = object
-    monkeypatch.setitem(sys.modules, "std_msgs", std_msgs)
-    monkeypatch.setitem(sys.modules, "std_msgs.msg", std_msgs.msg)
-
-    class DummyNode:
-        parameters = {}
-
-        def __init__(self, name):
-            self.name = name
-
-        def create_subscription(self, *args, **kwargs):
-            pass
-
-        def create_publisher(self, *args, **kwargs):
-            pass
-
-        class Logger:
-            def warning(self, *args, **kwargs):
-                pass
-
-            def info(self, *args, **kwargs):
-                pass
-
-        def get_logger(self):
-            return self.Logger()
-
-        def declare_parameter(self, name, default):
-            class Param:
-                def __init__(self, value):
-                    self.value = value
-
-            return Param(self.parameters.get(name, default))
-
-    # Provide path to existing cascade file
-    xml_file = tmp_path / "cascade.xml"
-    xml_file.write_text("test")
-    DummyNode.parameters = {"cascade_path": str(xml_file)}
-
-    rclpy = ModuleType("rclpy")
-    rclpy.node = ModuleType("rclpy.node")
-    rclpy.node.Node = DummyNode
-    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
-    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
-
-    cv2 = ModuleType("cv2")
-
-    class DummyCascade:
-        def __init__(self, xml_path):
-            self.xml_path = xml_path
-
-        def detectMultiScale(self, *args, **kwargs):
-            return []
-
-    cv2.CascadeClassifier = DummyCascade
-    cv2.data = None
-    monkeypatch.setitem(sys.modules, "cv2", cv2)
-
-    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
-    face_detector_node = importlib.import_module("altinet.nodes.face_detector_node")
-
-    node = face_detector_node.FaceDetectorNode()
-    assert isinstance(node.face_cascade, DummyCascade)
-    assert node.face_cascade.xml_path == str(xml_file)
-
-
-def test_initialization_with_cv2_data_missing_and_no_path(monkeypatch, tmp_path) -> None:
-    """When cv2.data is missing and no path provided, detection disabled."""
-
-    sensor_msgs = ModuleType("sensor_msgs")
-    sensor_msgs.msg = ModuleType("sensor_msgs.msg")
-    sensor_msgs.msg.Image = object
-    monkeypatch.setitem(sys.modules, "sensor_msgs", sensor_msgs)
-    monkeypatch.setitem(sys.modules, "sensor_msgs.msg", sensor_msgs.msg)
-
-    std_msgs = ModuleType("std_msgs")
-    std_msgs.msg = ModuleType("std_msgs.msg")
-    std_msgs.msg.Int32MultiArray = object
-    monkeypatch.setitem(sys.modules, "std_msgs", std_msgs)
-    monkeypatch.setitem(sys.modules, "std_msgs.msg", std_msgs.msg)
-
-    class DummyNode:
-        parameters = {}
-
-        def __init__(self, name):
-            self.name = name
-
-        def create_subscription(self, *args, **kwargs):
-            pass
-
-        def create_publisher(self, *args, **kwargs):
-            pass
-
-        class Logger:
-            def warning(self, *args, **kwargs):
-                pass
-
-            def info(self, *args, **kwargs):
-                pass
-
-        def get_logger(self):
-            return self.Logger()
-
-        def declare_parameter(self, name, default):
-            class Param:
-                def __init__(self, value):
-                    self.value = value
-
-            return Param(self.parameters.get(name, default))
-
-    rclpy = ModuleType("rclpy")
-    rclpy.node = ModuleType("rclpy.node")
-    rclpy.node.Node = DummyNode
-    monkeypatch.setitem(sys.modules, "rclpy", rclpy)
-    monkeypatch.setitem(sys.modules, "rclpy.node", rclpy.node)
-
-    cv2 = ModuleType("cv2")
-
-    class DummyCascade:
-        def __init__(self, xml_path):
-            self.xml_path = xml_path
-
-        def detectMultiScale(self, *args, **kwargs):
-            return []
-
-    cv2.CascadeClassifier = DummyCascade
-    cv2.data = None
-    monkeypatch.setitem(sys.modules, "cv2", cv2)
-
-    monkeypatch.delitem(sys.modules, "altinet.nodes.face_detector_node", raising=False)
-    face_detector_node = importlib.import_module("altinet.nodes.face_detector_node")
-
-    node = face_detector_node.FaceDetectorNode()
-    assert node.face_cascade is None
-
+    face_module = importlib.import_module("altinet.nodes.face_detector_node")
+    face_module.FaceDetectorNode()
+    assert recorded["topic"] == face_module.IMAGE_TOPIC


### PR DESCRIPTION
## Summary
- Add default cascade path and fallback logic for face detection
- Throttle disabled face detection log message
- Document cascade_path usage in README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c44e2f7584832fadcdbe384dd9d28c