### PR TITLE
Document user data directory and ensure creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ ros2 run altinet face_identifier_node
 
 ```
 
+### Preparing User Data
+
+`face_identifier_node` looks for known users under `assets/users`. The
+[`scripts/add_user.py`](scripts/add_user.py) helper stores information in this
+location by default, creating a directory for each person:
+
+```
+assets/users/
+  Alice/
+    metadata.json
+    photos/
+      photo_1.jpg
+      photo_2.jpg
+```
+
+Create this directory and populate it with user subdirectories before running
+`face_identifier_node` so that faces can be identified.
+
 OpenCV Haar cascade XML files for face and eye detection are available in
 `assets/haarcascades`. If your OpenCV build does not include these files,
 pass their location to `face_detector_node`:

--- a/scripts/add_user.py
+++ b/scripts/add_user.py
@@ -1,5 +1,10 @@
 #!/usr/bin/env python3
-"""Interactively add a user and capture training photos."""
+"""Interactively add a user and capture training photos.
+
+By default, this script saves information to ``assets/users/<name>`` relative
+to the repository root.  Each user directory contains a ``metadata.json`` file
+and a ``photos`` subfolder with the captured training images.
+"""
 
 import argparse
 import json

--- a/src/altinet/altinet/nodes/face_identifier_node.py
+++ b/src/altinet/altinet/nodes/face_identifier_node.py
@@ -25,6 +25,8 @@ except ImportError:  # pragma: no cover - dependency might be missing
     cv2 = None  # type: ignore
 
 
+# Directory containing known-user data. Populated by ``scripts/add_user.py``;
+# see ``README`` for details about its structure.
 REPO_USERS_DIR = Path(__file__).resolve().parents[3] / "assets" / "users"
 
 
@@ -78,8 +80,10 @@ class FaceIdentifierNode(Node):
             return
         users_dir = REPO_USERS_DIR
         if not users_dir.exists():
-            self.get_logger().warning(f"Users directory '{users_dir}' does not exist")
-            return
+            users_dir.mkdir(parents=True, exist_ok=True)
+            self.get_logger().info(
+                f"Users directory '{users_dir}' did not exist and was created"
+            )
         trained_any = False
         for user_dir in users_dir.iterdir():
             if not user_dir.is_dir():


### PR DESCRIPTION
## Summary
- clarify user data layout under `assets/users` in README
- document default output path in `scripts/add_user.py`
- reference README in `face_identifier_node` and create users directory if missing

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c52f4e3ed0832f9bb832c4cb59d7a0