### PR TITLE
Fix improper debug logging in face identifier node

### DIFF
--- a/src/altinet/altinet/nodes/face_identifier_node.py
+++ b/src/altinet/altinet/nodes/face_identifier_node.py
@@ -55,7 +55,7 @@ class FaceIdentifierNode(Node):
             return
         self._last_frame = self.bridge.imgmsg_to_cv2(msg, desired_encoding="rgb8")
         self.get_logger().debug(
-            "Received image frame %dx%d from camera", msg.width, msg.height
+            f"Received image frame {msg.width}x{msg.height} from camera"
         )
 
     def _faces_callback(self, msg: Int32MultiArray) -> None:


### PR DESCRIPTION
## Summary
- fix debug logging call in face_identifier_node to use formatted string

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c532f58e6c832f8361604e314fd031