### PR TITLE
Add logging for camera stream and face detection states

### DIFF
--- a/src/altinet/altinet/nodes/camera_node.py
+++ b/src/altinet/altinet/nodes/camera_node.py
@@ -27,6 +27,7 @@ class CameraNode(Node):
         if not cv2 or not self.cap or not self.cap.isOpened():
             self.get_logger().warning("Camera not available; no images will be published")
         self.timer = self.create_timer(0.1, self.timer_callback)
+        self._streaming_logged = False
 
     def timer_callback(self) -> None:
         if not self.cap or not self.cap.isOpened() or not self.bridge:
@@ -36,6 +37,9 @@ class CameraNode(Node):
             return
         msg = self.bridge.cv2_to_imgmsg(frame, encoding="bgr8")
         self.publisher.publish(msg)
+        if not self._streaming_logged:
+            self.get_logger().info("Publishing video stream from default camera")
+            self._streaming_logged = True
 
     def destroy_node(self) -> None:  # pragma: no cover - resource cleanup
         if self.cap:

--- a/src/altinet/altinet/nodes/face_detector_node.py
+++ b/src/altinet/altinet/nodes/face_detector_node.py
@@ -85,6 +85,7 @@ class FaceDetectorNode(Node):
         self.required_presence = 2.0
         self._warned_face_disabled = False
         self._received_frame = False
+        self._reported_no_faces = False
 
     def listener_callback(self, msg: Image) -> None:
         if not self._received_frame:
@@ -119,7 +120,11 @@ class FaceDetectorNode(Node):
                 self.get_logger().info(
                     f"Detected {len(faces)} face(s) with confidence {duration:.2f}s"
                 )
+            self._reported_no_faces = False
         else:
+            if not self._reported_no_faces:
+                self.get_logger().info("No faces detected in current frame")
+                self._reported_no_faces = True
             self.face_present_since = None
 
 


### PR DESCRIPTION
## Summary
- log when the camera node begins streaming frames
- report when no faces are detected in incoming frames

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c53af51a40832f80e1b367669a4039