### PR TITLE
Add offline speech synthesis service

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 
 An AI assistant using computer vision to contextualise and interpret the world.
 
+It includes an offline speech synthesis service for producing human-like
+spoken responses without relying on external APIs.
+
 This repository currently contains a skeleton implementation. See
 [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) for a description of the project
 layout and intended components.

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ opencv-python
 face-recognition
 
 llama-cpp-python
+pyttsx3

--- a/src/altinet/altinet/services/__init__.py
+++ b/src/altinet/altinet/services/__init__.py
@@ -7,4 +7,5 @@ __all__ = [
     "llm",
     "face_recognition",
     "face_tracker",
+    "speech",
 ]

--- a/src/altinet/altinet/services/speech.py
+++ b/src/altinet/altinet/services/speech.py
@@ -1,0 +1,29 @@
+"""Offline text-to-speech service."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class OfflineSpeechService:
+    """Convert text to speech locally using ``pyttsx3``.
+
+    The service wraps a ``pyttsx3`` engine instance to synthesise human-like
+    speech without needing internet connectivity. A pre-initialised engine can
+    be provided to ease testing.
+    """
+
+    def __init__(self, *, engine: Optional[Any] = None) -> None:
+        if engine is not None:
+            self._engine = engine
+        else:  # pragma: no cover - optional dependency
+            import pyttsx3
+
+            self._engine = pyttsx3.init()
+
+    def speak(self, text: str) -> None:
+        """Vocalise ``text`` using the configured engine."""
+
+        self._engine.say(text)
+        self._engine.runAndWait()
+

--- a/tests/test_speech_service.py
+++ b/tests/test_speech_service.py
@@ -1,0 +1,39 @@
+"""Tests for the offline speech synthesis service."""
+
+import sys
+from types import SimpleNamespace
+
+from altinet.services.speech import OfflineSpeechService
+
+
+class DummyEngine:
+    """Simple stub of a ``pyttsx3`` engine."""
+
+    def __init__(self) -> None:
+        self.spoken: list[str] = []
+        self.ran = False
+
+    def say(self, text: str) -> None:
+        self.spoken.append(text)
+
+    def runAndWait(self) -> None:  # noqa: N802 - library method name
+        self.ran = True
+
+
+def test_speak_uses_provided_engine() -> None:
+    engine = DummyEngine()
+    service = OfflineSpeechService(engine=engine)
+    service.speak("hello")
+    assert engine.spoken == ["hello"]
+    assert engine.ran
+
+
+def test_speak_initialises_pyttsx3(monkeypatch) -> None:
+    dummy = DummyEngine()
+    fake_module = SimpleNamespace(init=lambda: dummy)
+    monkeypatch.setitem(sys.modules, "pyttsx3", fake_module)
+    service = OfflineSpeechService()
+    service.speak("hi")
+    assert dummy.spoken == ["hi"]
+    assert dummy.ran
+


### PR DESCRIPTION
## Summary
- add offline text-to-speech service using pyttsx3
- document and expose the new speech synthesis service
- cover speech service with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c793961328832f82fd45d6bb836666