### PR TITLE
Log face identity checks

### DIFF
--- a/src/altinet/altinet/services/face_recognition.py
+++ b/src/altinet/altinet/services/face_recognition.py
@@ -80,11 +80,16 @@ class FaceRecognitionService:
         matches = self._encoder.compare_faces(self._known_encodings, encoding)
         if True in matches:
             index = matches.index(True)
-            return self._known_identities[index], self._known_confidences[index]
+            identity = self._known_identities[index]
+            confidence = self._known_confidences[index]
+        else:
+            identity, confidence = self._identifier(encoding)
+            if identity != "Unknown":
+                self._known_encodings.append(encoding)
+                self._known_identities.append(identity)
+                self._known_confidences.append(confidence)
 
-        identity, confidence = self._identifier(encoding)
-        if identity != "Unknown":
-            self._known_encodings.append(encoding)
-            self._known_identities.append(identity)
-            self._known_confidences.append(confidence)
+        logging.info(
+            "Checked face identity: %s (confidence %.2f)", identity, confidence
+        )
         return identity, confidence

--- a/tests/test_face_recognition_service.py
+++ b/tests/test_face_recognition_service.py
@@ -1,5 +1,7 @@
 """Tests for the face recognition service."""
 
+import logging
+
 from altinet.services.face_recognition import FaceRecognitionService
 
 
@@ -43,3 +45,11 @@ def test_training_adds_known_identity() -> None:
     service.train("face2", "Bob", 0.8)
     result = service.recognize("face2")
     assert result == ("Bob", 0.8)
+
+
+def test_recognize_logs_identity(caplog) -> None:
+    service = FaceRecognitionService(encoder=FakeEncoder())
+    service.train("face3", "Charlie", 0.7)
+    with caplog.at_level(logging.INFO):
+        service.recognize("face3")
+    assert "Checked face identity: Charlie" in caplog.text


### PR DESCRIPTION
## Summary
- log every face identity check with identity and confidence
- cover logging behavior in face recognition service test

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7aa496628832f8b6952f4b7b038dd