### PR TITLE
Add user deletion and enhanced photo capture for face recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,35 @@ ros2 run altinet face_detector_node --ros-args -p \
 
 The path may be absolute or relative to the repository root.
 
+## Face Recognition Utilities
 
+Use `scripts/add_user.py` to create a new user and capture initial training
+photos:
 
- 
+```bash
+python scripts/add_user.py
+```
+
+After collecting the initial images, augment the user's dataset with varied
+photos to improve recognition accuracy:
+
+```python
+from pathlib import Path
+from scripts.add_user import capture_additional_photos
+capture_additional_photos(Path("assets/users/<name>/photos"))
+```
+
+The helper captures 20 extra images, pausing one second between shots while
+prompting you to turn your head and, if available, swap hats.
+
+At runtime the face recognition cache can be cleared for an individual with:
+
+```python
+from altinet.services.face_recognition import FaceRecognitionService
+service = FaceRecognitionService()
+service.delete_user("<name>")
+```
+
 ## Local Node GUI
 
 A minimal Django-based GUI is available for running a local Altinet node.

--- a/scripts/add_user.py
+++ b/scripts/add_user.py
@@ -3,6 +3,7 @@
 
 import argparse
 import json
+import time
 from pathlib import Path
 from typing import Any, Dict
 
@@ -58,6 +59,40 @@ def capture_photos(out_dir: Path, count: int) -> None:
         if not ret:
             break
         filename = out_dir / f"photo_{i+1}.jpg"
+        cv2.imwrite(str(filename), frame)
+        print(f"Captured {filename}")
+    cap.release()
+
+
+def capture_additional_photos(out_dir: Path, count: int = 20) -> None:
+    """Capture extra photos with prompts for varied poses and hats.
+
+    A one-second delay is inserted between each capture to allow the user to
+    adjust their pose. For every image the user is prompted to turn their head
+    slightly and, if possible, change hats. If OpenCV or the camera is
+    unavailable, a message is printed and the function exits silently.
+    """
+    if cv2 is None:  # pragma: no cover - OpenCV not installed
+        print("OpenCV is not installed; skipping additional photo capture.")
+        return
+
+    cap = cv2.VideoCapture(0)  # pragma: no cover - requires hardware
+    if not cap.isOpened():  # pragma: no cover - requires hardware
+        print("Could not access camera; skipping additional photo capture.")
+        return
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for i in range(count):  # pragma: no cover - requires hardware
+        print(
+            "Prepare for photo {0}: turn head slightly and wear a different hat if possible.".format(
+                i + 1
+            )
+        )
+        time.sleep(1)
+        ret, frame = cap.read()
+        if not ret:
+            break
+        filename = out_dir / f"extra_{i+1}.jpg"
         cv2.imwrite(str(filename), frame)
         print(f"Captured {filename}")
     cap.release()

--- a/src/altinet/altinet/services/face_recognition.py
+++ b/src/altinet/altinet/services/face_recognition.py
@@ -55,6 +55,23 @@ class FaceRecognitionService:
         self._known_identities.append(identity)
         self._known_confidences.append(confidence)
 
+    def delete_user(self, identity: str) -> None:
+        """Remove all cached data for ``identity``.
+
+        Parameters
+        ----------
+        identity:
+            The name of the user to remove from the in-memory cache. Any
+            encodings, identities and confidences associated with this identity
+            are deleted. The method silently does nothing if the identity is not
+            present.
+        """
+        indexes = [i for i, known in enumerate(self._known_identities) if known == identity]
+        for index in reversed(indexes):
+            del self._known_encodings[index]
+            del self._known_identities[index]
+            del self._known_confidences[index]
+
     def recognize(self, image: Any) -> Tuple[str, float]:
         """Return the identity and confidence for ``image``.
 

--- a/tests/test_add_user_script.py
+++ b/tests/test_add_user_script.py
@@ -25,6 +25,13 @@ def test_capture_photos_without_cv2(monkeypatch, tmp_path, capsys):
     assert "OpenCV is not installed" in capsys.readouterr().out
 
 
+def test_capture_additional_photos_without_cv2(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(add_user, "cv2", None)
+    add_user.capture_additional_photos(tmp_path, 2)
+    assert not list(tmp_path.iterdir())
+    assert "OpenCV is not installed" in capsys.readouterr().out
+
+
 def test_train_user_photos_without_face_recognition(monkeypatch, tmp_path, capsys):
     monkeypatch.setattr(add_user, "face_recognition", None)
     add_user.train_user_photos(tmp_path, "Alice")

--- a/tests/test_face_recognition_service.py
+++ b/tests/test_face_recognition_service.py
@@ -53,3 +53,11 @@ def test_recognize_logs_identity(caplog) -> None:
     with caplog.at_level(logging.INFO):
         service.recognize("face3")
     assert "Checked face identity: Charlie" in caplog.text
+
+
+def test_delete_user_removes_identity() -> None:
+    service = FaceRecognitionService(encoder=FakeEncoder())
+    service.train("face4", "Dave", 0.6)
+    service.delete_user("Dave")
+    # After deletion, the face should be unknown again
+    assert service.recognize("face4") == ("Unknown", 0.0)


### PR DESCRIPTION
## Summary
- Allow removal of user data from `FaceRecognitionService`
- Provide script helper to capture additional varied training photos with prompts and delay
- Document face recognition utilities in the README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7e1528c94832f8ab2e356c21b49c8