### PR TITLE
Improve ROS dependency error reporting

### DIFF
--- a/ros2_ws/src/altinet/altinet/nodes/camera_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/camera_node.py
@@ -2,18 +2,22 @@
 
 from __future__ import annotations
 
+from typing import Optional
+
 try:  # pragma: no cover - optional dependency in tests
     import cv2
 except ImportError:  # pragma: no cover - executed when OpenCV missing
     cv2 = None
 
+_ROS_IMPORT_ERROR: Optional[Exception] = None
 try:  # pragma: no cover - ROS optional
     import rclpy
     from rclpy.node import Node
     from sensor_msgs.msg import Image
     from std_msgs.msg import Header
     from cv_bridge import CvBridge
-except Exception:  # pragma: no cover - executed in tests
+except ImportError as exc:  # pragma: no cover - executed in tests
+    _ROS_IMPORT_ERROR = exc
     rclpy = None
     Node = object  # type: ignore
     Image = Header = CvBridge = None
@@ -78,7 +82,10 @@ __all__ = ["CameraStream", "CameraNode"]
 
 def main(args=None):  # pragma: no cover - requires ROS runtime
     if rclpy is None:
-        raise RuntimeError("ROS 2 is not available in this environment")
+        message = "ROS 2 dependencies could not be imported"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     rclpy.init(args=args)
     node = CameraNode()
     try:

--- a/ros2_ws/src/altinet/altinet/nodes/event_manager_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/event_manager_node.py
@@ -8,13 +8,15 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
+_ROS_IMPORT_ERROR: Optional[Exception] = None
 try:  # pragma: no cover - optional when ROS 2 is not available
     import rclpy
     from rclpy.node import Node
     from altinet.msg import Event as EventMsg
     from altinet.msg import PersonTracks as PersonTracksMsg
     from altinet.msg import RoomPresence as RoomPresenceMsg
-except Exception:  # pragma: no cover - executed during tests
+except ImportError as exc:  # pragma: no cover - executed during tests
+    _ROS_IMPORT_ERROR = exc
     rclpy = None
     Node = object  # type: ignore
     EventMsg = PersonTracksMsg = RoomPresenceMsg = None
@@ -197,7 +199,10 @@ __all__ = ["EventManager", "EventManagerConfig", "EventManagerNode"]
 
 def main(args=None):  # pragma: no cover - requires ROS runtime
     if rclpy is None:
-        raise RuntimeError("ROS 2 is not available in this environment")
+        message = "ROS 2 dependencies could not be imported"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     rclpy.init(args=args)
     node = EventManagerNode()
     try:

--- a/ros2_ws/src/altinet/altinet/nodes/ros2_django_bridge_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/ros2_django_bridge_node.py
@@ -20,13 +20,15 @@ try:  # pragma: no cover - optional dependency
 except ImportError:  # pragma: no cover - executed when websocket-client missing
     websocket = None
 
+_ROS_IMPORT_ERROR: Optional[Exception] = None
 try:  # pragma: no cover
     import rclpy
     from rclpy.node import Node
     from altinet.msg import Event as EventMsg
     from altinet.msg import PersonTracks as PersonTracksMsg
     from altinet.msg import RoomPresence as RoomPresenceMsg
-except Exception:  # pragma: no cover - executed in tests
+except ImportError as exc:  # pragma: no cover - executed in tests
+    _ROS_IMPORT_ERROR = exc
     rclpy = None
     Node = object  # type: ignore
     EventMsg = PersonTracksMsg = RoomPresenceMsg = None
@@ -269,7 +271,10 @@ __all__ = [
 
 def main(args=None):  # pragma: no cover - requires ROS runtime
     if rclpy is None:
-        raise RuntimeError("ROS 2 is not available in this environment")
+        message = "ROS 2 dependencies could not be imported"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     rclpy.init(args=args)
     node = Ros2DjangoBridgeNode()
     try:

--- a/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
@@ -3,14 +3,16 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Iterable, List
+from typing import Iterable, List, Optional
 
+_ROS_IMPORT_ERROR: Optional[Exception] = None
 try:  # pragma: no cover - optional when ROS is unavailable
     import rclpy
     from rclpy.node import Node
     from altinet.msg import PersonDetections as PersonDetectionsMsg
     from altinet.msg import PersonTracks as PersonTracksMsg
-except Exception:  # pragma: no cover - executed during tests
+except ImportError as exc:  # pragma: no cover - executed during tests
+    _ROS_IMPORT_ERROR = exc
     rclpy = None
     Node = object  # type: ignore
     PersonDetectionsMsg = PersonTracksMsg = None
@@ -80,7 +82,10 @@ __all__ = ["TrackerPipeline", "TrackerNode"]
 
 def main(args=None):  # pragma: no cover - requires ROS runtime
     if rclpy is None:
-        raise RuntimeError("ROS 2 is not available in this environment")
+        message = "ROS 2 dependencies could not be imported"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     rclpy.init(args=args)
     node = TrackerNode()
     try:

--- a/ros2_ws/src/altinet/altinet/utils/ros_conversions.py
+++ b/ros2_ws/src/altinet/altinet/utils/ros_conversions.py
@@ -2,10 +2,11 @@
 
 from __future__ import annotations
 
-from typing import Iterable
+from typing import Iterable, Optional
 
 from .types import Detection, Event, RoomPresence, Track
 
+_ROS_IMPORT_ERROR: Optional[Exception] = None
 try:  # pragma: no cover - optional at test time
     from std_msgs.msg import Header
     from altinet.msg import (
@@ -17,7 +18,8 @@ try:  # pragma: no cover - optional at test time
         RoomPresence as RoomPresenceMsg,
     )
     from altinet.srv import ManualLightOverride
-except Exception:  # pragma: no cover - executed when ROS not available
+except ImportError as exc:  # pragma: no cover - executed when ROS not available
+    _ROS_IMPORT_ERROR = exc
     Header = EventMsg = PersonDetectionMsg = PersonDetectionsMsg = PersonTrackMsg = (
         PersonTracksMsg
     ) = RoomPresenceMsg = ManualLightOverride = None
@@ -27,7 +29,10 @@ def detections_to_msg(detections: Iterable[Detection], header) -> PersonDetectio
     """Convert detections to a ROS message."""
 
     if PersonDetectionsMsg is None:
-        raise RuntimeError("ROS messages are not available in this environment")
+        message = "ROS messages are not available in this environment"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     detections = list(detections)
     msg = PersonDetectionsMsg()
     msg.header = header
@@ -38,7 +43,10 @@ def detections_to_msg(detections: Iterable[Detection], header) -> PersonDetectio
 
 def single_detection_to_msg(detection: Detection, header) -> PersonDetectionMsg:
     if PersonDetectionMsg is None:
-        raise RuntimeError("ROS messages are not available in this environment")
+        message = "ROS messages are not available in this environment"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     msg = PersonDetectionMsg()
     msg.header = Header()
     msg.header.stamp = header.stamp
@@ -55,7 +63,10 @@ def single_detection_to_msg(detection: Detection, header) -> PersonDetectionMsg:
 
 def tracks_to_msg(tracks: Iterable[Track], header) -> PersonTracksMsg:
     if PersonTracksMsg is None:
-        raise RuntimeError("ROS messages are not available in this environment")
+        message = "ROS messages are not available in this environment"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     tracks = list(tracks)
     msg = PersonTracksMsg()
     msg.header = header
@@ -66,7 +77,10 @@ def tracks_to_msg(tracks: Iterable[Track], header) -> PersonTracksMsg:
 
 def single_track_to_msg(track: Track, header) -> PersonTrackMsg:
     if PersonTrackMsg is None:
-        raise RuntimeError("ROS messages are not available in this environment")
+        message = "ROS messages are not available in this environment"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     msg = PersonTrackMsg()
     msg.header = Header()
     msg.header.stamp = header.stamp
@@ -85,7 +99,10 @@ def single_track_to_msg(track: Track, header) -> PersonTrackMsg:
 
 def presence_to_msg(presence: RoomPresence, header) -> RoomPresenceMsg:
     if RoomPresenceMsg is None:
-        raise RuntimeError("ROS messages are not available in this environment")
+        message = "ROS messages are not available in this environment"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     msg = RoomPresenceMsg()
     msg.header = Header()
     msg.header.stamp = header.stamp
@@ -98,7 +115,10 @@ def presence_to_msg(presence: RoomPresence, header) -> RoomPresenceMsg:
 
 def event_to_msg(event: Event, header) -> EventMsg:
     if EventMsg is None:
-        raise RuntimeError("ROS messages are not available in this environment")
+        message = "ROS messages are not available in this environment"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
     msg = EventMsg()
     msg.header = Header()
     msg.header.stamp = header.stamp


### PR DESCRIPTION
## Summary
- capture the exact ImportError raised when ROS 2 dependencies are unavailable across all nodes
- surface the stored import failure in the RuntimeError message so users know which package is missing
- propagate the detailed import error through the ROS message conversion helpers as well

## Testing
- PYTHONPATH=backend pytest ros2_ws/src/altinet/altinet/tests


------
https://chatgpt.com/codex/tasks/task_e_68c957166fe4832f86e37d3a1507aac3