### PR TITLE
Add required interface dependencies

### DIFF
--- a/ros2_ws/src/altinet_interfaces/CMakeLists.txt
+++ b/ros2_ws/src/altinet_interfaces/CMakeLists.txt
@@ -3,6 +3,8 @@ project(altinet_interfaces)
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
+find_package(builtin_interfaces REQUIRED)
+find_package(std_msgs REQUIRED)
 
 set(msg_files
   "msg/Event.msg"


### PR DESCRIPTION
## Summary
- add builtin_interfaces and std_msgs dependencies to the altinet interfaces package to match generated types

## Testing
- colcon build --symlink-install *(fails: colcon: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca0325d2f4832fa2b250afc9c79fb7