### PR TITLE
Fix altinet interfaces to use std_msgs Header

### DIFF
--- a/ros2_ws/src/altinet_interfaces/CMakeLists.txt
+++ b/ros2_ws/src/altinet_interfaces/CMakeLists.txt
@@ -3,7 +3,6 @@ project(altinet_interfaces)
 
 find_package(ament_cmake REQUIRED)
 find_package(rosidl_default_generators REQUIRED)
-find_package(builtin_interfaces REQUIRED)
 find_package(std_msgs REQUIRED)
 
 set(msg_files
@@ -22,7 +21,7 @@ set(srv_files
 rosidl_generate_interfaces(${PROJECT_NAME}
   ${msg_files}
   ${srv_files}
-  DEPENDENCIES builtin_interfaces std_msgs
+  DEPENDENCIES std_msgs
 )
 
 ament_export_dependencies(rosidl_default_runtime)

--- a/ros2_ws/src/altinet_interfaces/msg/Event.msg
+++ b/ros2_ws/src/altinet_interfaces/msg/Event.msg
@@ -1,4 +1,4 @@
-builtin_interfaces/Header header
+std_msgs/Header header
 string type
 string subject_id
 string room_id

--- a/ros2_ws/src/altinet_interfaces/msg/PersonDetection.msg
+++ b/ros2_ws/src/altinet_interfaces/msg/PersonDetection.msg
@@ -1,4 +1,4 @@
-builtin_interfaces/Header header
+std_msgs/Header header
 float32 x
 float32 y
 float32 w

--- a/ros2_ws/src/altinet_interfaces/msg/PersonTrack.msg
+++ b/ros2_ws/src/altinet_interfaces/msg/PersonTrack.msg
@@ -1,4 +1,4 @@
-builtin_interfaces/Header header
+std_msgs/Header header
 int32 track_id
 float32 x
 float32 y

--- a/ros2_ws/src/altinet_interfaces/msg/RoomPresence.msg
+++ b/ros2_ws/src/altinet_interfaces/msg/RoomPresence.msg
@@ -1,4 +1,4 @@
-builtin_interfaces/Header header
+std_msgs/Header header
 string room_id
 int32 count
 int32[] track_ids

--- a/ros2_ws/src/altinet_interfaces/package.xml
+++ b/ros2_ws/src/altinet_interfaces/package.xml
@@ -9,7 +9,6 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>rosidl_default_generators</build_depend>
-  <build_depend>builtin_interfaces</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>


### PR DESCRIPTION
## Summary
- update the interface message definitions to use std_msgs/Header instead of builtin_interfaces/Header
- drop the unused builtin_interfaces dependency from the interface package build setup

## Testing
- colcon build --symlink-install *(fails: `colcon` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca042c7bd4832f9ab20d2068efa8ef