### PR TITLE
Ensure onnxruntime dependency is installed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 numpy>=1.24
+onnxruntime>=1.16
 Django>=4.2,<5.0
 djangorestframework>=3.14
 django-filter>=23.5

--- a/ros2_ws/src/altinet/setup.py
+++ b/ros2_ws/src/altinet/setup.py
@@ -15,7 +15,7 @@ setup(
         ('share/' + package_name + '/launch', glob('altinet/launch/*.py')),
         ('share/' + package_name + '/config', glob('altinet/config/*.yaml')),
     ],
-    install_requires=['setuptools'],
+    install_requires=['setuptools', 'onnxruntime>=1.16'],
     zip_safe=True,
     maintainer='Altinet Maintainer',
     maintainer_email='maintainer@example.com',


### PR DESCRIPTION
## Summary
- include onnxruntime in the project-level Python requirements to support the YOLO detector
- ensure the ROS 2 package installs onnxruntime when built so the detector node can start

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68caacbc61f0832f97f52d56586a13ae