### PR TITLE
Handle --editable flag in develop command

### DIFF
--- a/ros2_ws/src/altinet/setup.py
+++ b/ros2_ws/src/altinet/setup.py
@@ -2,6 +2,39 @@ from glob import glob
 from pathlib import Path
 
 from setuptools import find_packages, setup
+from setuptools.command.develop import develop as _DevelopCommand
+
+
+class DevelopCommand(_DevelopCommand):
+    """Custom develop command that tolerates ``--editable``."""
+
+    user_options = list(_DevelopCommand.user_options)
+    if not any(option[0].startswith('editable') for option in user_options):
+        user_options.append(
+            (
+                'editable',
+                'e',
+                'Install the package in editable mode (compatibility flag).',
+            )
+        )
+
+    boolean_options = list(getattr(_DevelopCommand, 'boolean_options', []))
+    if 'editable' not in boolean_options:
+        boolean_options.append('editable')
+
+    def initialize_options(self):
+        super().initialize_options()
+        if not hasattr(self, 'editable'):
+            self.editable = False
+        if not hasattr(self, 'build_directory'):
+            self.build_directory = None
+
+    def finalize_options(self):
+        if getattr(self, 'editable', False) and not getattr(self, 'build_directory', None):
+            build_base = getattr(self, 'build_base', None)
+            default_build_dir = Path(build_base) if build_base else Path('build') / 'develop'
+            self.build_directory = str(default_build_dir)
+        super().finalize_options()
 
 package_name = 'altinet'
 
@@ -22,6 +55,7 @@ setup(
     description='Altinet perception stack',
     license='MIT',
     tests_require=['pytest'],
+    cmdclass={'develop': DevelopCommand},
     entry_points={
         'console_scripts': [
             'camera_node = altinet.nodes.camera_node:main',


### PR DESCRIPTION
## Summary
- add a custom setuptools develop command that tolerates the --editable flag used by colcon
- default the build directory when editable installs are requested and register the command in setup()

## Testing
- python3 setup.py develop --editable *(fails in this environment when attempting to download onnxruntime)*

------
https://chatgpt.com/codex/tasks/task_e_68caaf313c7c832f841474f95aaccc48