### PR TITLE
Handle global editable flag in setup.py

### DIFF
--- a/ros2_ws/src/altinet/setup.py
+++ b/ros2_ws/src/altinet/setup.py
@@ -1,8 +1,20 @@
+import sys
 from glob import glob
 from pathlib import Path
 
 from setuptools import find_packages, setup
 from setuptools.command.develop import develop as _DevelopCommand
+
+
+# ``colcon`` forwards the ``--editable`` flag as a *global* option when invoking
+# ``setup.py``.  ``setuptools`` does not recognise this global option which
+# results in an early failure before our custom ``develop`` command gets a
+# chance to handle it.  Strip the compatibility flag from ``sys.argv`` so the
+# command parser can continue normally.  The flag is still honoured by the
+# custom develop command below.
+for editable_flag in ('--editable', '-e'):
+    if editable_flag in sys.argv:
+        sys.argv.remove(editable_flag)
 
 
 class DevelopCommand(_DevelopCommand):


### PR DESCRIPTION
## Summary
- strip the global --editable/-e compatibility flag before invoking setuptools so colcon no longer fails during parsing

## Testing
- `colcon build --symlink-install` *(fails: colcon is not installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce0578d9f0832f90aa72b141207a4f