### PR TITLE
Handle colcon uninstall flag in setup

### DIFF
--- a/ros2_ws/src/altinet/setup.py
+++ b/ros2_ws/src/altinet/setup.py
@@ -1,9 +1,11 @@
+import shutil
 import sys
 from glob import glob
 from pathlib import Path
 
 from setuptools import find_packages, setup
 from setuptools.command.develop import develop as _DevelopCommand
+from setuptools.command.install import install as _InstallCommand
 
 
 # ``colcon`` forwards the ``--editable`` flag as a *global* option when invoking
@@ -59,6 +61,135 @@ class DevelopCommand(_DevelopCommand):
             self.build_directory = str(default_build_dir)
         super().finalize_options()
 
+
+class InstallCommand(_InstallCommand):
+    """Custom install command that understands the ``--uninstall`` flag."""
+
+    user_options = list(_InstallCommand.user_options)
+    if not any(option[0].startswith('uninstall') for option in user_options):
+        user_options.append(
+            (
+                'uninstall',
+                'u',
+                'Uninstall this distribution before installing (compatibility flag).',
+            )
+        )
+
+    boolean_options = list(getattr(_InstallCommand, 'boolean_options', []))
+    if 'uninstall' not in boolean_options:
+        boolean_options.append('uninstall')
+
+    def initialize_options(self):
+        super().initialize_options()
+        if not hasattr(self, 'uninstall'):
+            self.uninstall = False
+
+    def run(self):
+        if getattr(self, 'uninstall', False):
+            self._uninstall_previous_installation()
+        super().run()
+
+    # ------------------------------------------------------------------
+    # Compatibility helpers
+    # ------------------------------------------------------------------
+    def _uninstall_previous_installation(self):
+        record_option = getattr(self, 'record', None)
+        record_path = None
+        if record_option:
+            record_path = Path(record_option)
+            if not record_path.is_absolute():
+                record_path = Path.cwd() / record_path
+
+        records = []
+        if record_path and record_path.exists():
+            try:
+                with record_path.open() as record_file:
+                    records = [line.strip() for line in record_file if line.strip()]
+            except OSError:
+                records = []
+
+        root_path = None
+        root_value = getattr(self, 'root', None)
+        if root_value:
+            root_path = Path(root_value)
+
+        for entry in records:
+            recorded_path = Path(entry)
+            target_path = self._resolve_recorded_path(recorded_path, root_path)
+            self._remove_path(target_path, root_path)
+
+        if record_path and record_path.exists():
+            try:
+                record_path.unlink()
+            except OSError:
+                pass
+
+        if not records:
+            self._best_effort_cleanup_without_record()
+
+    def _resolve_recorded_path(self, recorded_path, root_path):
+        if root_path is None:
+            return recorded_path
+        if recorded_path.is_absolute():
+            parts = recorded_path.parts[1:]
+            if parts:
+                return root_path.joinpath(*parts)
+            return root_path
+        return root_path / recorded_path
+
+    def _remove_path(self, path, root_path):
+        try:
+            exists = path.exists()
+        except OSError:
+            exists = False
+        if not exists:
+            return
+        if path.is_dir():
+            shutil.rmtree(path, ignore_errors=True)
+        else:
+            try:
+                path.unlink()
+            except IsADirectoryError:
+                shutil.rmtree(path, ignore_errors=True)
+            except OSError:
+                pass
+        if root_path:
+            self._cleanup_empty_parents(path.parent, root_path)
+
+    def _cleanup_empty_parents(self, start_dir, root_path):
+        try:
+            root_resolved = root_path.resolve()
+        except OSError:
+            root_resolved = root_path
+        current = start_dir
+        while current and current != current.parent:
+            try:
+                if current.resolve() == root_resolved:
+                    break
+            except OSError:
+                break
+            try:
+                current.rmdir()
+            except OSError:
+                break
+            current = current.parent
+
+    def _best_effort_cleanup_without_record(self):
+        install_lib = getattr(self, 'install_lib', None)
+        if install_lib:
+            package_dir = Path(install_lib) / self.distribution.get_name()
+            if package_dir.exists():
+                shutil.rmtree(package_dir, ignore_errors=True)
+        install_scripts = getattr(self, 'install_scripts', None)
+        if install_scripts:
+            scripts_dir = Path(install_scripts)
+            if scripts_dir.exists():
+                for script in scripts_dir.glob(f"{self.distribution.get_name()}*"):
+                    try:
+                        script.unlink()
+                    except OSError:
+                        pass
+
 package_name = 'altinet'
 
 setup(
@@ -78,7 +209,7 @@ setup(
     description='Altinet perception stack',
     license='MIT',
     tests_require=['pytest'],
-    cmdclass={'develop': DevelopCommand},
+    cmdclass={'develop': DevelopCommand, 'install': InstallCommand},
     entry_points={
         'console_scripts': [
             'camera_node = altinet.nodes.camera_node:main',


### PR DESCRIPTION
## Summary
- extend the custom setup.py tooling with an InstallCommand that accepts the `--uninstall` flag forwarded by colcon
- remove previously recorded files (and fall back to a best-effort cleanup) before running the standard installation logic

## Testing
- python3 setup.py install --record record.txt --uninstall
- pytest ros2_ws/src/altinet/altinet/tests *(fails: ImportError: No module named 'altinet_backend')*


------
https://chatgpt.com/codex/tasks/task_e_68ce0ff46d7c832fa7279f0cc098b0db