### PR TITLE
Add ament_python export to altinet_interfaces package

### DIFF
--- a/ros2_ws/src/altinet_interfaces/package.xml
+++ b/ros2_ws/src/altinet_interfaces/package.xml
@@ -15,4 +15,8 @@
   <exec_depend>std_msgs</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
 </package>


### PR DESCRIPTION
## Summary
- add an export block to the altinet_interfaces package manifest so it declares the ament_python build type

## Testing
- colcon build *(fails: `colcon` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ce1375d358832fa9b3d84c3907076b