### PR TITLE
Handle editable installs for altinet_interfaces

### DIFF
--- a/ros2_ws/src/altinet_interfaces/setup.py
+++ b/ros2_ws/src/altinet_interfaces/setup.py
@@ -1,6 +1,36 @@
 from pathlib import Path
+import sys
 
 from setuptools import find_packages, setup
+
+
+def _normalize_setup_arguments():
+    """Work around build tools passing unsupported global options.
+
+    Some build workflows (notably `colcon build --symlink-install`) invoke the
+    package's ``setup.py`` script with a top-level ``--editable`` flag.  The
+    flag is understood by ``pip`` but it is not a recognized global option for
+    ``setuptools``'s ``setup.py`` entry point, which causes the build to abort
+    before any of the actual commands run.  To keep the build working we strip
+    this flag and, when it is the only argument provided, fall back to the
+    ``develop`` command that pip would normally select for editable installs.
+    """
+
+    if "--editable" not in sys.argv:
+        return
+
+    # Remove all occurrences of the unsupported flag so setuptools does not
+    # exit with ``error: option --editable not recognized``.
+    sys.argv = [arg for arg in sys.argv if arg != "--editable"]
+
+    # When ``--editable`` was the only argument, replicate pip's behaviour by
+    # defaulting to the ``develop`` command.  This keeps editable installs
+    # functional when invoked directly (e.g. ``python setup.py --editable``).
+    if len(sys.argv) == 1:
+        sys.argv.append("develop")
+
+
+_normalize_setup_arguments()
 
 package_name = "altinet_interfaces"
 


### PR DESCRIPTION
## Summary
- normalize arguments passed to setup.py so that unexpected --editable flags do not abort the build
- default to running the develop command when --editable is the only argument, matching pip's behaviour

## Testing
- python3 setup.py --editable

------
https://chatgpt.com/codex/tasks/task_e_68ce15b76e10832fa0389f0a5f680d40