### PR TITLE
Convert altinet package to ament_cmake

### DIFF
--- a/ros2_ws/src/altinet/CMakeLists.txt
+++ b/ros2_ws/src/altinet/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.8)
+project(altinet)
+
+find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+
+ament_python_install_package(${PROJECT_NAME})
+
+install(
+  PROGRAMS
+    scripts/camera_node
+    scripts/detector_node
+    scripts/tracker_node
+    scripts/event_manager_node
+    scripts/lighting_control_node
+    scripts/ros2_django_bridge_node
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY altinet/launch
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(
+  DIRECTORY altinet/config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(
+  FILES package.xml
+  DESTINATION share/${PROJECT_NAME}
+)
+
+install(
+  FILES resource/${PROJECT_NAME}
+  DESTINATION share/ament_index/resource_index/packages
+)
+
+ament_package()

--- a/ros2_ws/src/altinet/package.xml
+++ b/ros2_ws/src/altinet/package.xml
@@ -6,7 +6,8 @@
   <maintainer email="maintainer@example.com">Altinet Maintainer</maintainer>
   <license>MIT</license>
 
-  <buildtool_depend>ament_python</buildtool_depend>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ament_cmake_python</build_depend>
 
   <exec_depend>rclpy</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
@@ -17,7 +18,7 @@
   <exec_depend>altinet_interfaces</exec_depend>
 
   <export>
-    <build_type>ament_python</build_type>
+    <build_type>ament_cmake</build_type>
   </export>
 
 </package>

--- a/ros2_ws/src/altinet/scripts/camera_node
+++ b/ros2_ws/src/altinet/scripts/camera_node
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Wrapper executable for the camera node."""
+
+from altinet.nodes.camera_node import main
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/altinet/scripts/detector_node
+++ b/ros2_ws/src/altinet/scripts/detector_node
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Wrapper executable for the detector node."""
+
+from altinet.nodes.detector_node import main
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/altinet/scripts/event_manager_node
+++ b/ros2_ws/src/altinet/scripts/event_manager_node
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Wrapper executable for the event manager node."""
+
+from altinet.nodes.event_manager_node import main
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/altinet/scripts/lighting_control_node
+++ b/ros2_ws/src/altinet/scripts/lighting_control_node
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Wrapper executable for the lighting control node."""
+
+from altinet.nodes.lighting_control_node import main
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/altinet/scripts/ros2_django_bridge_node
+++ b/ros2_ws/src/altinet/scripts/ros2_django_bridge_node
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Wrapper executable for the ROS 2 to Django bridge node."""
+
+from altinet.nodes.ros2_django_bridge_node import main
+
+
+if __name__ == "__main__":
+    main()

--- a/ros2_ws/src/altinet/scripts/tracker_node
+++ b/ros2_ws/src/altinet/scripts/tracker_node
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Wrapper executable for the tracker node."""
+
+from altinet.nodes.tracker_node import main
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- switch the altinet ROS 2 package to the ament_cmake build type with a new CMakeLists.txt that installs the Python package, launch files, and configuration resources
- add executable Python wrappers so the existing node entry points continue to be available via `ros2 run`
- update package.xml to declare the new build tool and dependency

## Testing
- not run (colcon not installed in environment)


------
https://chatgpt.com/codex/tasks/task_e_68ce1d9052e4832f92ca0c8d302a2f6d