### PR TITLE
Pin numpy dependency below v2 for ROS2 nodes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.24
+numpy>=1.24,<2.0
 onnxruntime>=1.16
 Django>=4.2,<5.0
 djangorestframework>=3.14


### PR DESCRIPTION
## Summary
- pin numpy to a <2.0 release to ensure OpenCV and cv_bridge binary wheels remain compatible with the ROS2 nodes

## Testing
- not run (dependency-only change)


------
https://chatgpt.com/codex/tasks/task_e_68ce222fda1c832f9cd122d5821488c4