### PR TITLE
Fix YOLO config path resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,12 +49,14 @@ Django backend for dashboards and historical analysis.
    Or run individual nodes for debugging:
 
    ```bash
-   ros2 run altinet detector_node --ros-args -p room_id:=living_room -p config:=config/yolo.yaml
-   ros2 run altinet tracker_node
-   ros2 run altinet event_manager_node --ros-args -p presence_timeout_s:=3.0
-   ros2 run altinet lighting_control_node --ros-args -p cooldown_s:=15.0
-   ros2 run altinet ros2_django_bridge_node --ros-args -p privacy_config:=config/privacy.yaml
-   ```
+  ros2 run altinet detector_node --ros-args -p room_id:=living_room
+  ros2 run altinet tracker_node
+  ros2 run altinet event_manager_node --ros-args -p presence_timeout_s:=3.0
+  ros2 run altinet lighting_control_node --ros-args -p cooldown_s:=15.0
+  ros2 run altinet ros2_django_bridge_node --ros-args -p privacy_config:=config/privacy.yaml
+  ```
+
+  The detector node automatically loads the packaged YOLO configuration. Override the path with ``-p config:=/custom/path.yaml`` if you need a different model setup.
 
 4. Regenerate documentation:
 

--- a/ros2_ws/src/altinet/altinet/launch/altinet_per_room.launch.py
+++ b/ros2_ws/src/altinet/altinet/launch/altinet_per_room.launch.py
@@ -7,9 +7,12 @@ from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 
+from altinet.utils.config import default_yolo_config_path
+
 
 def generate_launch_description() -> LaunchDescription:
     room_id = LaunchConfiguration("room_id")
+    default_config = str(default_yolo_config_path())
     return LaunchDescription(
         [
             DeclareLaunchArgument("room_id", default_value="living_room"),
@@ -24,7 +27,7 @@ def generate_launch_description() -> LaunchDescription:
                 package="altinet",
                 executable="detector_node",
                 name="detector_node",
-                parameters=[{"room_id": room_id, "config": "config/yolo.yaml"}],
+                parameters=[{"room_id": room_id, "config": default_config}],
             ),
             Node(
                 package="altinet",

--- a/ros2_ws/src/altinet/altinet/nodes/detector_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/detector_node.py
@@ -24,7 +24,7 @@ except ImportError as exc:  # pragma: no cover - executed during tests
     Node = object  # type: ignore
     Image = Header = CvBridge = PersonDetectionsMsg = None
 
-from ..utils.config import load_file
+from ..utils.config import default_yolo_config_path, load_file
 from ..utils.models import YoloConfig, YoloV8Detector
 from ..utils.ros_conversions import detections_to_msg
 from ..utils.types import Detection
@@ -75,7 +75,8 @@ class DetectorNode(Node):  # pragma: no cover - requires ROS runtime
 
     def __init__(self) -> None:
         super().__init__("detector_node")
-        self.declare_parameter("config", str(Path("config/yolo.yaml")))
+        default_config = default_yolo_config_path()
+        self.declare_parameter("config", str(default_config))
         self.declare_parameter("room_id", "room_1")
         config_path = Path(self.get_parameter("config").value)
         room_id = str(self.get_parameter("room_id").value)

--- a/ros2_ws/src/altinet/altinet/utils/config.py
+++ b/ros2_ws/src/altinet/altinet/utils/config.py
@@ -6,6 +6,9 @@ import json
 from pathlib import Path
 from typing import Any, Dict
 
+
+_PACKAGE_ROOT = Path(__file__).resolve().parent.parent
+
 try:  # pragma: no cover - optional dependency
     import yaml
 except ImportError:  # pragma: no cover - executed when PyYAML unavailable
@@ -50,4 +53,16 @@ def _coerce_value(value: str) -> Any:
         return value
 
 
-__all__ = ["load_file"]
+def package_config_path(*relative: str) -> Path:
+    """Return an absolute path inside the package ``config`` directory."""
+
+    return _PACKAGE_ROOT.joinpath("config", *relative)
+
+
+def default_yolo_config_path() -> Path:
+    """Return the packaged default YOLO configuration path."""
+
+    return package_config_path("yolo.yaml")
+
+
+__all__ = ["load_file", "package_config_path", "default_yolo_config_path"]

--- a/scripts/run_demo.py
+++ b/scripts/run_demo.py
@@ -10,6 +10,7 @@ import cv2
 
 from altinet.nodes.detector_node import DetectorPipeline, load_config
 from altinet.nodes.tracker_node import TrackerPipeline
+from altinet.utils.config import default_yolo_config_path
 from altinet.utils.models import YoloV8Detector
 
 
@@ -36,7 +37,12 @@ def run_demo(video_path: Path, config_path: Path, room_id: str) -> None:
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("video", type=Path, help="Path to a demo video file")
-    parser.add_argument("--config", type=Path, default=Path("config/yolo.yaml"), help="YOLO config path")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=default_yolo_config_path(),
+        help="YOLO config path",
+    )
     parser.add_argument("--room", default="demo_room", help="Room identifier")
     args = parser.parse_args()
     run_demo(args.video, args.config, args.room)


### PR DESCRIPTION
## Summary
- add utilities to resolve packaged config paths and use them for the detector defaults
- update the demo script and per-room launch file to reuse the packaged YOLO config path
- document the new default behaviour in the README

## Testing
- pytest *(fails: ImportError: No module named 'altinet_backend')*
- ros2 run altinet detector_node *(fails: command not found: ros2)*

------
https://chatgpt.com/codex/tasks/task_e_68ce26a4787c832fb324f487b3fc36e6