### PR TITLE
Install viewer nodes with ROS2 package

### DIFF
--- a/ros2_ws/src/altinet/CMakeLists.txt
+++ b/ros2_ws/src/altinet/CMakeLists.txt
@@ -9,11 +9,13 @@ ament_python_install_package(${PROJECT_NAME})
 install(
   PROGRAMS
     scripts/camera_node
+    scripts/camera_viewer_node
     scripts/detector_node
     scripts/tracker_node
     scripts/event_manager_node
     scripts/lighting_control_node
     scripts/ros2_django_bridge_node
+    scripts/visualizer_node
   DESTINATION lib/${PROJECT_NAME}
 )
 


### PR DESCRIPTION
## Summary
- add the camera and visualizer wrapper scripts to the ROS 2 install target so they are deployed with the package executables

## Testing
- `colcon build` *(fails: `colcon` command not found; ROS 2 is not installed in the execution environment)*
- `source install/setup.bash` *(fails: install artifacts not generated because the build could not run)*
- `ros2 run altinet camera_viewer_node` *(fails: `ros2` command not found without a ROS 2 installation)*

------
https://chatgpt.com/codex/tasks/task_e_68cf3c8880ac832f8d61567937748451