### PR TITLE
Add console logging for person detections

### DIFF
--- a/ros2_ws/src/altinet/altinet/nodes/detector_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/detector_node.py
@@ -100,6 +100,20 @@ class DetectorNode(Node):  # pragma: no cover - requires ROS runtime
         detections = self.pipeline.process(
             frame, self.room_id, msg.header.frame_id, timestamp
         )
+        if detections:
+            for detection in detections:
+                bbox = detection.bbox
+                self.get_logger().info(
+                    "Detected person in room '%s' (frame '%s') at "
+                    "x=%.1f, y=%.1f, w=%.1f, h=%.1f with confidence %.2f",
+                    detection.room_id,
+                    detection.frame_id,
+                    bbox.x,
+                    bbox.y,
+                    bbox.w,
+                    bbox.h,
+                    detection.confidence,
+                )
         header = Header()
         header.stamp = msg.header.stamp
         header.frame_id = msg.header.frame_id


### PR DESCRIPTION
## Summary
- log detected people from DetectorNode using the ROS logger, including bounding box and confidence details

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest ros2_ws/src/altinet/altinet/tests/test_detector.py`


------
https://chatgpt.com/codex/tasks/task_e_68d0a80042f4832f95930dfa9e43591d