### PR TITLE
Fix visualizer logging format

### DIFF
--- a/ros2_ws/src/altinet/altinet/nodes/visualizer_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/visualizer_node.py
@@ -201,10 +201,9 @@ class VisualizerNode(Node):  # pragma: no cover - requires ROS runtime
                 boxes.append(
                     f"(x1={x1}, y1={y1}, x2={x2}, y2={y2})"
                 )
+            boxes_description = "; ".join(boxes)
             self.get_logger().info(
-                "Received %d person detections with bounding boxes: %s",
-                len(boxes),
-                "; ".join(boxes),
+                f"Received {len(boxes)} person detections with bounding boxes: {boxes_description}"
             )
 
     def _on_tracks(self, msg: PersonTracksMsg) -> None:


### PR DESCRIPTION
## Summary
- format the person detection log message before logging
- prevent passing extra positional arguments to the ROS logger

## Testing
- pytest -p no:django ros2_ws/src/altinet/altinet/tests/test_visualizer.py

------
https://chatgpt.com/codex/tasks/task_e_68d11f8d13d8832f921c67ecb912a67c