### PR TITLE
Clamp scaled boxes to image bounds

### DIFF
--- a/ros2_ws/src/altinet/altinet/tests/test_detector.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_detector.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import numpy as np
 
 from altinet.nodes.detector_node import DetectorPipeline, load_config
+from altinet.utils.models import _scale_box
 from altinet.utils.types import BoundingBox, Detection
 
 
@@ -45,3 +46,15 @@ def test_load_config_reads_yaml(tmp_path):
     config = load_config(config_path)
     assert config.model_path == Path("assets/models/yolov8n.onnx")
     assert config.conf_thresh == 0.5
+
+
+def test_scale_box_clamps_boxes_outside_top_left():
+    box = np.array([-30.0, -20.0, 40.0, 60.0], dtype=np.float32)
+    scaled = _scale_box(box, ratio=1.0, padding=(0.0, 0.0), original_shape=(100, 200))
+    bbox = BoundingBox(*scaled)
+
+    assert bbox.x >= 0.0
+    assert bbox.y >= 0.0
+    assert bbox.w >= 0.0
+    assert bbox.h >= 0.0
+    assert bbox.w == 0.0

--- a/ros2_ws/src/altinet/altinet/utils/models.py
+++ b/ros2_ws/src/altinet/altinet/utils/models.py
@@ -150,11 +150,18 @@ def _scale_box(
     w /= ratio
     h /= ratio
 
+    orig_height = float(original_shape[0])
+    orig_width = float(original_shape[1])
+
     x1 = max(cx - w / 2.0, 0.0)
     y1 = max(cy - h / 2.0, 0.0)
-    x2 = min(cx + w / 2.0, float(original_shape[1]))
-    y2 = min(cy + h / 2.0, float(original_shape[0]))
-    return x1, y1, x2 - x1, y2 - y1
+    x2 = min(max(cx + w / 2.0, 0.0), orig_width)
+    y2 = min(max(cy + h / 2.0, 0.0), orig_height)
+
+    width = max(x2 - x1, 0.0)
+    height = max(y2 - y1, 0.0)
+
+    return x1, y1, width, height
 
 
 def _nms(boxes: List[BoundingBox], scores: List[float], iou_thresh: float) -> List[int]:


### PR DESCRIPTION
## Summary
- clamp scaled YOLO boxes to image bounds before computing width and height
- force non-negative bounding box dimensions when scaling detections
- add a detector unit test covering boxes centered outside the frame

## Testing
- PYTHONPATH=ros2_ws/src:backend pytest ros2_ws/src/altinet/altinet/tests/test_detector.py

------
https://chatgpt.com/codex/tasks/task_e_68d121a1df40832f996cad3f1d86cc36