### PR TITLE
Propagate image dimensions through detection and track interfaces

### DIFF
--- a/ros2_ws/src/altinet/altinet/nodes/event_manager_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/event_manager_node.py
@@ -177,13 +177,15 @@ class EventManagerNode(Node):  # pragma: no cover - requires ROS 2 runtime
         tracks = []
         for track_msg in msg.tracks:
             bbox = BoundingBox(track_msg.x, track_msg.y, track_msg.w, track_msg.h)
+            image_height = int(getattr(track_msg, "image_height", 0)) or 1
+            image_width = int(getattr(track_msg, "image_width", 0)) or 1
             track = Track(
                 track_id=track_msg.track_id,
                 bbox=bbox,
                 confidence=1.0,
                 room_id=msg.room_id,
                 timestamp=now,
-                image_size=(1080, 1920),
+                image_size=(image_height, image_width),
             )
             tracks.append(track)
         events, presences = self.manager.update(tracks)

--- a/ros2_ws/src/altinet/altinet/nodes/ros2_django_bridge_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/ros2_django_bridge_node.py
@@ -241,6 +241,8 @@ class Ros2DjangoBridgeNode(Node):  # pragma: no cover - requires ROS runtime
         tracks = []
         for track_msg in msg.tracks:
             bbox = BoundingBox(track_msg.x, track_msg.y, track_msg.w, track_msg.h)
+            image_height = int(getattr(track_msg, "image_height", 0)) or 1
+            image_width = int(getattr(track_msg, "image_width", 0)) or 1
             tracks.append(
                 Track(
                     track_id=track_msg.track_id,
@@ -248,7 +250,7 @@ class Ros2DjangoBridgeNode(Node):  # pragma: no cover - requires ROS runtime
                     confidence=1.0,
                     room_id=msg.room_id,
                     timestamp=datetime.utcnow(),
-                    image_size=(1, 1),
+                    image_size=(image_height, image_width),
                 )
             )
         self.bridge.publish_tracks(msg.room_id, tracks, datetime.utcnow())

--- a/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
@@ -63,13 +63,15 @@ class TrackerNode(Node):  # pragma: no cover - requires ROS runtime
         detections = []
         for det in msg.detections:
             bbox = (det.x, det.y, det.w, det.h)
+            image_height = int(getattr(det, "image_height", 0)) or 1
+            image_width = int(getattr(det, "image_width", 0)) or 1
             detection = Detection(
                 bbox=BoundingBox(*bbox),
                 confidence=det.conf,
                 room_id=msg.room_id,
                 frame_id=det.frame_id,
                 timestamp=datetime.utcnow(),
-                image_size=(1080, 1920),
+                image_size=(image_height, image_width),
             )
             detections.append(detection)
         tracks = self.pipeline.update(detections)

--- a/ros2_ws/src/altinet/altinet/tests/test_event_manager.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_event_manager.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime, timedelta
 
+import pytest
+
 from altinet.nodes.event_manager_node import EventManager, EventManagerConfig
 from altinet.utils.geometry import RoomGeometry
 from altinet.utils.types import BoundingBox, Track
@@ -12,14 +14,20 @@ class DummyGeometry(RoomGeometry):
         super().__init__(room_id=room_id, homography=None, roi=None)
 
 
-def make_track(track_id: int, x: float, y: float, timestamp: datetime) -> Track:
+def make_track(
+    track_id: int,
+    x: float,
+    y: float,
+    timestamp: datetime,
+    image_size=(720, 1280),
+) -> Track:
     return Track(
         track_id=track_id,
         bbox=BoundingBox(x, y, 50.0, 80.0),
         confidence=0.9,
         room_id="living_room",
         timestamp=timestamp,
-        image_size=(1080, 1920),
+        image_size=image_size,
     )
 
 
@@ -30,13 +38,22 @@ def test_event_manager_generates_entry_exit_and_position_change():
     )
     t0 = datetime.utcnow()
     events, presence = manager.update([make_track(1, 10.0, 20.0, t0)])
-    assert any(event.type == "ENTRY" for event in events)
+    entry_event = next(event for event in events if event.type == "ENTRY")
+    centroid = entry_event.payload["centroid"]
+    assert centroid[0] == pytest.approx((10.0 + 25.0) / 1280.0)
+    assert centroid[1] == pytest.approx((20.0 + 40.0) / 720.0)
     assert presence[0].count == 1
 
     events, _ = manager.update(
         [make_track(1, 40.0, 20.0, t0 + timedelta(milliseconds=33))]
     )
-    assert any(event.type == "POSITION_CHANGE" for event in events)
+    move_event = next(event for event in events if event.type == "POSITION_CHANGE")
+    moved_centroid = move_event.payload["centroid"]
+    previous_centroid = move_event.payload["previous"]
+    assert previous_centroid[0] == pytest.approx(centroid[0])
+    assert previous_centroid[1] == pytest.approx(centroid[1])
+    assert moved_centroid[0] == pytest.approx((40.0 + 25.0) / 1280.0)
+    assert moved_centroid[1] == pytest.approx((20.0 + 40.0) / 720.0)
 
     # Advance time to trigger timeout
     manager.last_seen[1] = datetime.utcnow() - timedelta(seconds=0.2)

--- a/ros2_ws/src/altinet/altinet/tests/test_tracker.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_tracker.py
@@ -13,7 +13,7 @@ def make_detection(x: float, y: float, timestamp: datetime) -> Detection:
         room_id="living_room",
         frame_id="cam",
         timestamp=timestamp,
-        image_size=(1080, 1920),
+        image_size=(720, 1280),
     )
 
 
@@ -24,6 +24,7 @@ def test_tracker_preserves_identity():
     tracks_frame1 = tracker.update(detections_frame1)
     assert len(tracks_frame1) == 1
     track_id = tracks_frame1[0].track_id
+    assert tracks_frame1[0].image_size == (720, 1280)
 
     detections_frame2 = [make_detection(12.0, 22.0, t0 + timedelta(milliseconds=33))]
     tracks_frame2 = tracker.update(detections_frame2)

--- a/ros2_ws/src/altinet/altinet/utils/ros_conversions.py
+++ b/ros2_ws/src/altinet/altinet/utils/ros_conversions.py
@@ -56,6 +56,9 @@ def single_detection_to_msg(detection: Detection, header) -> PersonDetectionMsg:
     msg.w = detection.bbox.w
     msg.h = detection.bbox.h
     msg.conf = detection.confidence
+    image_height, image_width = detection.image_size
+    msg.image_width = int(image_width)
+    msg.image_height = int(image_height)
     msg.room_id = detection.room_id
     msg.frame_id = detection.frame_id
     return msg
@@ -93,6 +96,9 @@ def single_track_to_msg(track: Track, header) -> PersonTrackMsg:
     cx, cy = track.centroid()
     msg.cx = cx
     msg.cy = cy
+    image_height, image_width = track.image_size
+    msg.image_width = int(image_width)
+    msg.image_height = int(image_height)
     msg.room_id = track.room_id
     return msg
 

--- a/ros2_ws/src/altinet_interfaces/msg/PersonDetection.msg
+++ b/ros2_ws/src/altinet_interfaces/msg/PersonDetection.msg
@@ -4,5 +4,7 @@ float32 y
 float32 w
 float32 h
 float32 conf
+uint32 image_width
+uint32 image_height
 string room_id
 string frame_id

--- a/ros2_ws/src/altinet_interfaces/msg/PersonTrack.msg
+++ b/ros2_ws/src/altinet_interfaces/msg/PersonTrack.msg
@@ -6,4 +6,6 @@ float32 w
 float32 h
 float32 cx
 float32 cy
+uint32 image_width
+uint32 image_height
 string room_id


### PR DESCRIPTION
## Summary
- add image dimensions to the person detection and track message definitions
- populate the new fields in ROS conversion helpers and propagate them through tracker and event manager nodes
- refresh tests to cover non-1080p inputs and verify normalised coordinates

## Testing
- PYTHONPATH=ros2_ws/src/altinet pytest ros2_ws/src/altinet/altinet/tests -p no:django

------
https://chatgpt.com/codex/tasks/task_e_68d22c6b90d0832f973ecba624e58281