### PR TITLE
Raise tracker confidence threshold to 0.75

### DIFF
--- a/ros2_ws/src/altinet/altinet/config/tracker.yaml
+++ b/ros2_ws/src/altinet/altinet/config/tracker.yaml
@@ -1,5 +1,5 @@
 tracker_node:
   ros__parameters:
-    track_thresh: 0.45
+    track_thresh: 0.75
     match_thresh: 0.7
     max_age: 30

--- a/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
@@ -39,7 +39,7 @@ class TrackerNode(Node):  # pragma: no cover - requires ROS runtime
 
     def __init__(self) -> None:
         super().__init__("tracker_node")
-        self.declare_parameter("track_thresh", 0.4)
+        self.declare_parameter("track_thresh", 0.75)
         self.declare_parameter("match_thresh", 0.7)
         self.declare_parameter("max_age", 30)
 

--- a/ros2_ws/src/altinet/altinet/utils/tracking.py
+++ b/ros2_ws/src/altinet/altinet/utils/tracking.py
@@ -15,7 +15,7 @@ from .types import Detection, Track
 class ByteTrackConfig:
     """Configuration for the multi-object tracker."""
 
-    track_thresh: float = 0.4
+    track_thresh: float = 0.75
     match_thresh: float = 0.7
     max_age: int = 30
     min_hits: int = 3


### PR DESCRIPTION
## Summary
- raise the ByteTrack tracking confidence threshold to 0.75 to limit tracking to higher confidence detections
- update the tracker node default parameter and ROS 2 parameter file to match the new requirement

## Testing
- PYTHONPATH=backend pytest *(fails: backend/spaces/tests/test_encryption.py::test_rtsp_url_encrypted_at_rest – database row not returned as expected)*

------
https://chatgpt.com/codex/tasks/task_e_68d23c468fb0832f8ab8f922f7becca3