### PR TITLE
Prefer track bounding boxes in visualizer

### DIFF
--- a/ros2_ws/src/altinet/altinet/nodes/visualizer_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/visualizer_node.py
@@ -240,10 +240,13 @@ class VisualizerNode(Node):  # pragma: no cover - requires ROS runtime
             tracks = self._filter_by_timestamp(tracks, tracks_stamp, image_stamp)
 
         annotated = frame.copy()
-        if self._draw_detections and detections:
-            self._draw_detection_boxes(annotated, detections, width, height)
+        drew_tracks = False
         if self._draw_tracks and tracks:
             self._draw_track_boxes(annotated, tracks, width, height)
+            drew_tracks = True
+        if self._draw_detections and detections and not drew_tracks:
+            # Fall back to raw detections only when no track is available.
+            self._draw_detection_boxes(annotated, detections, width, height)
 
         annotated_msg = self._bridge.cv2_to_imgmsg(annotated, encoding="bgr8")
         annotated_msg.header = msg.header


### PR DESCRIPTION
## Summary
- draw tracked person boxes on annotated frames whenever tracking data is present
- fall back to detection boxes only when tracks are unavailable

## Testing
- PYTHONPATH=backend pytest ros2_ws/src/altinet/altinet/tests/test_visualizer.py

------
https://chatgpt.com/codex/tasks/task_e_68d23e7257e0832f995b8f27ca0ba7c3