### PR TITLE
Add detector inference throttling parameter

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -24,7 +24,29 @@ graph LR
 ### Detector
 
 `DetectorNode` loads YOLOv8n from `assets/models/yolov8n.onnx`, filters to
-person detections, and publishes `altinet/PersonDetections`.
+person detections, and publishes `altinet/PersonDetections`. It exposes a
+`min_detection_interval` parameter (seconds) that throttles how often new
+frames are pushed through the network. Setting the interval to a small value
+such as `0.2` seconds caps inference around 5 FPS, which keeps the
+visualizer updated in near real-time while trimming CPU usage on edge
+devices.
+
+Example parameter override:
+
+```yaml
+detector_node:
+  ros__parameters:
+    min_detection_interval: 0.25  # seconds between inference runs
+```
+
+You can also adjust the parameter at runtime:
+
+```bash
+ros2 param set /detector_node min_detection_interval 0.25
+```
+
+Tune the interval based on hardware characteristics—the higher the value, the
+more frames are skipped, reducing workload at the cost of responsiveness.
 
 ### Identity Service
 


### PR DESCRIPTION
## Summary
- add a `min_detection_interval` ROS parameter to the detector node and track monotonic time between runs
- skip frames that arrive before the interval expires while logging throttling diagnostics
- document how to configure the interval so deployments can balance CPU usage with visualizer freshness

## Testing
- PYTHONPATH=backend pytest *(fails: backend/spaces/tests/test_encryption.py::test_rtsp_url_encrypted_at_rest - TypeError: 'NoneType' object is not subscriptable)*

------
https://chatgpt.com/codex/tasks/task_e_68d25044a9b0832fa2ed4ce28f30f399