### PR TITLE
Launch identity service in ROS 2 launch configurations

### DIFF
--- a/ros2_ws/src/altinet/altinet/launch/altinet_full_system.launch.py
+++ b/ros2_ws/src/altinet/altinet/launch/altinet_full_system.launch.py
@@ -74,5 +74,10 @@ def generate_launch_description() -> LaunchDescription:
                     }
                 ],
             ),
+            Node(
+                package="altinet",
+                executable="identity_node",
+                name="identity_node",
+            ),
         ]
     )

--- a/ros2_ws/src/altinet/altinet/launch/altinet_per_room.launch.py
+++ b/ros2_ws/src/altinet/altinet/launch/altinet_per_room.launch.py
@@ -41,5 +41,10 @@ def generate_launch_description() -> LaunchDescription:
                 name="visualizer_node",
                 parameters=[{"room_id": room_id}],
             ),
+            Node(
+                package="altinet",
+                executable="identity_node",
+                name="identity_node",
+            ),
         ]
     )


### PR DESCRIPTION
## Summary
- add the identity service node to the full system launch description
- include the identity service node in the single-room launch configuration so per-room deployments expose the service

## Testing
- not run (ROS 2 environment unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d25cdcf0f0832fbc7db6a4cc3e4115