### PR TITLE
Add identity node launcher script

### DIFF
--- a/ros2_ws/src/altinet/CMakeLists.txt
+++ b/ros2_ws/src/altinet/CMakeLists.txt
@@ -11,6 +11,7 @@ install(
     scripts/camera_node
     scripts/camera_viewer_node
     scripts/detector_node
+    scripts/identity_node
     scripts/tracker_node
     scripts/event_manager_node
     scripts/lighting_control_node

--- a/ros2_ws/src/altinet/scripts/identity_node
+++ b/ros2_ws/src/altinet/scripts/identity_node
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""Wrapper executable for the identity node."""
+from altinet.nodes.identity_node import main
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a wrapper script to launch the identity node via `ros2 run`
- include the new launcher in the CMake install list so it is deployed with the other nodes

## Testing
- colcon build *(fails: `colcon`: command not found in container environment)*
- ros2 run altinet identity_node *(fails: `ros2`: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d289a222b4832fb4d2b48c2ab0ace7