### PR TITLE
Throttle detection rate and predict tracks between updates

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -26,17 +26,16 @@ graph LR
 `DetectorNode` loads YOLOv8n from `assets/models/yolov8n.onnx`, filters to
 person detections, and publishes `altinet/PersonDetections`. It exposes a
 `min_detection_interval` parameter (seconds) that throttles how often new
-frames are pushed through the network. Setting the interval to a small value
-such as `0.2` seconds caps inference around 5 FPS, which keeps the
-visualizer updated in near real-time while trimming CPU usage on edge
-devices.
+frames are pushed through the network. The default is now `1.5` seconds to
+significantly reduce inference load. Lower the interval if your hardware can
+handle additional work to tighten responsiveness.
 
 Example parameter override:
 
 ```yaml
 detector_node:
   ros__parameters:
-    min_detection_interval: 0.25  # seconds between inference runs
+    min_detection_interval: 0.25  # override default 1.5s cadence
 ```
 
 You can also adjust the parameter at runtime:
@@ -58,7 +57,10 @@ resolved identity alongside the bounding box coordinates.
 ### Tracker
 
 `TrackerNode` wraps a ByteTrack-inspired tracker that maintains stable
-IDs. It publishes `altinet/PersonTracks` for downstream consumers.
+IDs. It publishes `altinet/PersonTracks` for downstream consumers and now
+periodically extrapolates bounding boxes between detector updates using the
+tracked velocity. This keeps the visualizer aligned with the person's motion
+even while inference is throttled to every 1.5 seconds.
 
 ### Event Manager
 

--- a/ros2_ws/src/altinet/altinet/config/tracker.yaml
+++ b/ros2_ws/src/altinet/altinet/config/tracker.yaml
@@ -3,3 +3,5 @@ tracker_node:
     track_thresh: 0.45
     match_thresh: 0.7
     max_age: 30
+    prediction_publish_rate: 10.0
+    prediction_horizon_seconds: 1.5

--- a/ros2_ws/src/altinet/altinet/launch/altinet_full_system.launch.py
+++ b/ros2_ws/src/altinet/altinet/launch/altinet_full_system.launch.py
@@ -31,6 +31,7 @@ def generate_launch_description() -> LaunchDescription:
                         "config": PathJoinSubstitution(
                             [altinet_share, "config", "yolo.yaml"]
                         ),
+                        "min_detection_interval": 1.5,
                     }
                 ],
             ),

--- a/ros2_ws/src/altinet/altinet/launch/altinet_per_room.launch.py
+++ b/ros2_ws/src/altinet/altinet/launch/altinet_per_room.launch.py
@@ -27,7 +27,13 @@ def generate_launch_description() -> LaunchDescription:
                 package="altinet",
                 executable="detector_node",
                 name="detector_node",
-                parameters=[{"room_id": room_id, "config": default_config}],
+                parameters=[
+                    {
+                        "room_id": room_id,
+                        "config": default_config,
+                        "min_detection_interval": 1.5,
+                    }
+                ],
             ),
             Node(
                 package="altinet",

--- a/ros2_ws/src/altinet/altinet/nodes/detector_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/detector_node.py
@@ -82,7 +82,7 @@ class DetectorNode(Node):  # pragma: no cover - requires ROS runtime
         self.declare_parameter("room_id", "room_1")
         self.declare_parameter("identity_service_enabled", True)
         self.declare_parameter("identity_service_timeout", 0.25)
-        self.declare_parameter("min_detection_interval", 0.0)
+        self.declare_parameter("min_detection_interval", 1.5)
         config_path = Path(self.get_parameter("config").value)
         room_id = str(self.get_parameter("room_id").value)
         config = load_config(config_path)

--- a/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from datetime import datetime
 from typing import Iterable, List, Optional
 
@@ -9,13 +10,14 @@ _ROS_IMPORT_ERROR: Optional[Exception] = None
 try:  # pragma: no cover - optional when ROS is unavailable
     import rclpy
     from rclpy.node import Node
+    from std_msgs.msg import Header
     from altinet.msg import PersonDetections as PersonDetectionsMsg
     from altinet.msg import PersonTracks as PersonTracksMsg
 except ImportError as exc:  # pragma: no cover - executed during tests
     _ROS_IMPORT_ERROR = exc
     rclpy = None
     Node = object  # type: ignore
-    PersonDetectionsMsg = PersonTracksMsg = None
+    Header = PersonDetectionsMsg = PersonTracksMsg = None
 
 from ..utils.tracking import ByteTrack, ByteTrackConfig
 from ..utils.ros_conversions import tracks_to_msg
@@ -33,6 +35,32 @@ class TrackerPipeline:
 
         return self.tracker.update(detections)
 
+    def predict(
+        self,
+        tracks: Iterable[Track],
+        now: datetime,
+        max_seconds: Optional[float] = None,
+    ) -> List[Track]:
+        """Project tracks forward using their velocity estimates."""
+
+        horizon = max_seconds if max_seconds is not None and max_seconds > 0.0 else None
+        predicted: List[Track] = []
+        for track in tracks:
+            dt = (now - track.timestamp).total_seconds()
+            if horizon is not None:
+                dt = min(dt, horizon)
+            if dt <= 0.0 or track.velocity == (0.0, 0.0):
+                predicted.append(track)
+                continue
+            bbox = BoundingBox(
+                track.bbox.x + track.velocity[0] * dt,
+                track.bbox.y + track.velocity[1] * dt,
+                track.bbox.w,
+                track.bbox.h,
+            )
+            predicted.append(replace(track, bbox=bbox, timestamp=now))
+        return predicted
+
 
 class TrackerNode(Node):  # pragma: no cover - requires ROS runtime
     """ROS 2 node bridging detection and tracking stages."""
@@ -42,6 +70,8 @@ class TrackerNode(Node):  # pragma: no cover - requires ROS runtime
         self.declare_parameter("track_thresh", 0.4)
         self.declare_parameter("match_thresh", 0.7)
         self.declare_parameter("max_age", 30)
+        self.declare_parameter("prediction_publish_rate", 10.0)
+        self.declare_parameter("prediction_horizon_seconds", 1.5)
 
         config = ByteTrackConfig(
             track_thresh=float(self.get_parameter("track_thresh").value),
@@ -49,6 +79,19 @@ class TrackerNode(Node):  # pragma: no cover - requires ROS runtime
             max_age=int(self.get_parameter("max_age").value),
         )
         self.pipeline = TrackerPipeline(ByteTrack(config))
+        self._last_tracks: List[Track] = []
+        self._last_frame_id: str = ""
+        rate_param = self.get_parameter("prediction_publish_rate").value
+        try:
+            prediction_rate = float(rate_param)
+        except (TypeError, ValueError):
+            prediction_rate = 0.0
+        horizon_param = self.get_parameter("prediction_horizon_seconds").value
+        try:
+            horizon = float(horizon_param)
+        except (TypeError, ValueError):
+            horizon = 0.0
+        self._prediction_horizon = horizon if horizon > 0.0 else None
         self.subscription = self.create_subscription(
             PersonDetectionsMsg,
             "/altinet/person_detections",
@@ -58,6 +101,12 @@ class TrackerNode(Node):  # pragma: no cover - requires ROS runtime
         self.publisher = self.create_publisher(
             PersonTracksMsg, "/altinet/person_tracks", 10
         )
+        self._prediction_timer = None
+        if prediction_rate > 0.0:
+            period = 1.0 / prediction_rate
+            self._prediction_timer = self.create_timer(
+                period, self._publish_predictions
+            )
 
     def _on_detections(self, msg: PersonDetectionsMsg) -> None:
         detections = []
@@ -75,8 +124,27 @@ class TrackerNode(Node):  # pragma: no cover - requires ROS runtime
             )
             detections.append(detection)
         tracks = self.pipeline.update(detections)
+        self._last_tracks = list(tracks)
+        self._last_frame_id = msg.header.frame_id
         header = msg.header
         self.publisher.publish(tracks_to_msg(tracks, header))
+
+    def _publish_predictions(self) -> None:
+        if not self._last_tracks or Header is None:
+            return
+        frame_id = self._last_frame_id
+        if not frame_id:
+            return
+        now = datetime.utcnow()
+        predicted = self.pipeline.predict(
+            self._last_tracks, now, self._prediction_horizon
+        )
+        if not predicted:
+            return
+        header = Header()
+        header.stamp = self.get_clock().now().to_msg()
+        header.frame_id = frame_id
+        self.publisher.publish(tracks_to_msg(predicted, header))
 
 
 __all__ = ["TrackerPipeline", "TrackerNode"]

--- a/ros2_ws/src/altinet/altinet/tests/test_tracker.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_tracker.py
@@ -2,6 +2,8 @@
 
 from datetime import datetime, timedelta
 
+import pytest
+
 from altinet.nodes.tracker_node import TrackerPipeline
 from altinet.utils.types import BoundingBox, Detection
 
@@ -30,3 +32,30 @@ def test_tracker_preserves_identity():
     tracks_frame2 = tracker.update(detections_frame2)
     assert len(tracks_frame2) == 1
     assert tracks_frame2[0].track_id == track_id
+
+
+def test_tracker_estimates_velocity_per_second():
+    tracker = TrackerPipeline()
+    t0 = datetime.utcnow()
+    tracker.update([make_detection(10.0, 20.0, t0)])
+    t1 = t0 + timedelta(seconds=2)
+    tracks = tracker.update([make_detection(14.0, 24.0, t1)])
+    assert len(tracks) == 1
+    assert tracks[0].velocity == pytest.approx((2.0, 2.0))
+
+
+def test_tracker_predict_projects_tracks_forward():
+    tracker = TrackerPipeline()
+    t0 = datetime.utcnow()
+    tracker.update([make_detection(10.0, 20.0, t0)])
+    t1 = t0 + timedelta(seconds=1)
+    tracks = tracker.update([make_detection(12.0, 24.0, t1)])
+    now = t1 + timedelta(seconds=1)
+    predicted = tracker.predict(tracks, now, max_seconds=1.5)
+    assert len(predicted) == 1
+    original = tracks[0]
+    projected = predicted[0]
+    assert projected is not original
+    assert projected.timestamp == now
+    assert original.bbox.x == pytest.approx(12.0)
+    assert projected.bbox.x == pytest.approx(14.0)

--- a/ros2_ws/src/altinet/altinet/utils/types.py
+++ b/ros2_ws/src/altinet/altinet/utils/types.py
@@ -66,7 +66,8 @@ class Track:
         room_id: Room identifier associated with the track.
         timestamp: Timestamp of the most recent update.
         image_size: Dimensions of the frame that produced the update.
-        velocity: Estimated pixel displacement between consecutive frames.
+        velocity: Estimated pixel velocity (pixels per second) based on
+            recent detections.
         hits: Number of successful detection associations.
         age: Number of consecutive updates without a detection match.
     """


### PR DESCRIPTION
## Summary
- throttle the detector so inference runs every 1.5 seconds by default and wire the launch files to pass the new cadence
- have the tracker extrapolate bounding boxes between detections using velocity estimates with configurable publish rate and horizon
- document the reduced detector load and predictive tracking while adding tests that cover the new velocity calculation and projection

## Testing
- PYTHONPATH=backend:ros2_ws/src DJANGO_SETTINGS_MODULE=altinet_backend.settings pytest ros2_ws/src/altinet/altinet/tests/test_tracker.py

------
https://chatgpt.com/codex/tasks/task_e_68d28edd373c832fb3c6527e866f3b0b