### PR TITLE
Fix detector debug logging formatting

### DIFF
--- a/ros2_ws/src/altinet/altinet/nodes/detector_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/detector_node.py
@@ -131,10 +131,9 @@ class DetectorNode(Node):  # pragma: no cover - requires ROS runtime
             self._skipped_frames += 1
             if self._skipped_frames == 1 or self._skipped_frames % 10 == 0:
                 self.get_logger().debug(
-                    "Skipping camera frame; %d frame(s) deferred to honor "
-                    "min_detection_interval=%.2fs",
-                    self._skipped_frames,
-                    self._min_detection_interval,
+                    "Skipping camera frame; "
+                    f"{self._skipped_frames} frame(s) deferred to honor "
+                    f"min_detection_interval={self._min_detection_interval:.2f}s"
                 )
             return
         if not self._connection_logged:


### PR DESCRIPTION
## Summary
- format the detector node's skipped frame debug message before passing it to the ROS logger to avoid argument errors

## Testing
- pytest ros2_ws/src/altinet/altinet/tests/test_detector.py *(fails: ImportError: No module named 'altinet_backend')*

------
https://chatgpt.com/codex/tasks/task_e_68d295e37320832f9607f61458bdcebb