### PR TITLE
Add Altinet logo to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Altinet
 
+<p align="center">
+  <img src="assets/branding/altinet-logo.png" alt="Altinet logo" width="200">
+</p>
+
 Altinet is a home perception stack that detects, tracks and contextualises
 people in real-time. The project couples a ROS 2 based pipeline with a
 Django backend for dashboards and historical analysis.


### PR DESCRIPTION
## Summary
- display the Altinet logo centered at the top of the README for improved branding (expects `assets/branding/altinet-logo.png` to be provided separately)
- ensure the repository no longer includes the binary logo asset so it can be uploaded manually

## Testing
- not run (documentation-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d33949a9cc832fb30ed004ad550bba