### PR TITLE
Add face capture pipeline and ROS integration

### DIFF
--- a/ros2_ws/src/altinet/altinet/launch/altinet_full_system.launch.py
+++ b/ros2_ws/src/altinet/altinet/launch/altinet_full_system.launch.py
@@ -45,6 +45,28 @@ def generate_launch_description() -> LaunchDescription:
             ),
             Node(
                 package="altinet",
+                executable="face_capture_node",
+                name="face_capture_node",
+                parameters=[
+                    {
+                        "room_id": room_id,
+                        "capture_cadence_s": 2.0,
+                        "minimum_quality": 0.65,
+                        "improvement_margin": 0.05,
+                        "frame_history": 60,
+                        "frame_tolerance_s": 0.2,
+                        "face_padding": 0.2,
+                        "model_name": "buffalo_l",
+                        "model_root": PathJoinSubstitution(
+                            [altinet_share, "assets", "models"]
+                        ),
+                        "det_size": [640, 640],
+                        "ctx_id": 0,
+                    }
+                ],
+            ),
+            Node(
+                package="altinet",
                 executable="visualizer_node",
                 name="visualizer_node",
                 parameters=[{"room_id": room_id}],

--- a/ros2_ws/src/altinet/altinet/msg/__init__.py
+++ b/ros2_ws/src/altinet/altinet/msg/__init__.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 try:
     from altinet_interfaces.msg import (
         Event,
+        FaceSnapshot,
+        FaceSnapshots,
         PersonDetection,
         PersonDetections,
         PersonTrack,
@@ -19,6 +21,8 @@ except ImportError as exc:  # pragma: no cover - requires ROS interfaces
 
 __all__ = [
     "Event",
+    "FaceSnapshot",
+    "FaceSnapshots",
     "PersonDetection",
     "PersonDetections",
     "PersonTrack",

--- a/ros2_ws/src/altinet/altinet/nodes/face_capture_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/face_capture_node.py
@@ -1,0 +1,215 @@
+"""ROS 2 node that captures high-quality face snapshots for tracked people."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+from ..utils.face_capture import FaceCaptureConfig, FaceCapturePipeline, InsightFaceAnalyzer
+from ..utils.ros_conversions import face_snapshot_to_msg, face_snapshots_to_msg
+from ..utils.types import BoundingBox, Track
+
+_ROS_IMPORT_ERROR: Optional[Exception] = None
+try:  # pragma: no cover - optional when ROS is unavailable
+    import rclpy
+    from rclpy.node import Node
+    from builtin_interfaces.msg import Time
+    from sensor_msgs.msg import Image
+    from std_msgs.msg import Header
+    from cv_bridge import CvBridge
+    from altinet.msg import FaceSnapshots as FaceSnapshotsMsg
+    from altinet.msg import PersonTracks as PersonTracksMsg
+    from altinet.srv import RequestFaceSnapshot
+except ImportError as exc:  # pragma: no cover - executed during tests
+    _ROS_IMPORT_ERROR = exc
+    rclpy = None
+    Node = object  # type: ignore
+    Time = Image = Header = CvBridge = FaceSnapshotsMsg = PersonTracksMsg = RequestFaceSnapshot = None
+
+
+def _ros_time_to_datetime(stamp: Time) -> datetime:
+    """Convert a ROS ``builtin_interfaces/Time`` to ``datetime``."""
+
+    if stamp is None:
+        return datetime.utcnow()
+    seconds = float(getattr(stamp, "sec", 0))
+    nanoseconds = float(getattr(stamp, "nanosec", 0))
+    total_seconds = seconds + nanoseconds / 1_000_000_000.0
+    return datetime.fromtimestamp(total_seconds, tz=timezone.utc).replace(tzinfo=None)
+
+
+class _FallbackAnalyzer:
+    """Analyzer used when InsightFace cannot be initialised."""
+
+    def detect(self, image: Any):  # pragma: no cover - trivial
+        return []
+
+
+class FaceCaptureNode(Node):  # pragma: no cover - requires ROS runtime
+    """ROS 2 node that produces ``FaceSnapshot`` messages."""
+
+    def __init__(self) -> None:
+        super().__init__("face_capture_node")
+        if FaceSnapshotsMsg is None or PersonTracksMsg is None or CvBridge is None:
+            raise RuntimeError("ROS message dependencies for face capture are unavailable")
+
+        self.declare_parameter("room_id", "living_room")
+        self.declare_parameter("model_name", "buffalo_l")
+        self.declare_parameter("model_root", "")
+        self.declare_parameter("capture_cadence_s", 2.0)
+        self.declare_parameter("minimum_quality", 0.6)
+        self.declare_parameter("improvement_margin", 0.05)
+        self.declare_parameter("frame_history", 45)
+        self.declare_parameter("frame_tolerance_s", 0.1)
+        self.declare_parameter("face_padding", 0.15)
+        self.declare_parameter("det_size", [640, 640])
+        self.declare_parameter("ctx_id", 0)
+
+        self.room_id = str(self.get_parameter("room_id").value)
+        model_name = str(self.get_parameter("model_name").value)
+        model_root_param = self.get_parameter("model_root").value
+        model_root = str(model_root_param) if model_root_param else None
+        det_size_param = self.get_parameter("det_size").value
+        if isinstance(det_size_param, (list, tuple)) and len(det_size_param) == 2:
+            det_size = int(det_size_param[0]), int(det_size_param[1])
+        else:
+            det_size = (640, 640)
+        ctx_id = int(self.get_parameter("ctx_id").value)
+
+        config = FaceCaptureConfig(
+            minimum_quality=float(self.get_parameter("minimum_quality").value),
+            improvement_margin=float(self.get_parameter("improvement_margin").value),
+            min_time_between_snapshots=float(self.get_parameter("capture_cadence_s").value),
+            frame_history=int(self.get_parameter("frame_history").value),
+            face_padding=float(self.get_parameter("face_padding").value),
+            frame_tolerance_s=float(self.get_parameter("frame_tolerance_s").value),
+        )
+
+        try:
+            analyzer = InsightFaceAnalyzer(
+                model_name=model_name,
+                model_root=model_root,
+                det_size=det_size,
+                ctx_id=ctx_id,
+            )
+            self.get_logger().info(
+                "Initialized InsightFace analyzer for face capture (model=%s)", model_name
+            )
+        except Exception as exc:  # pragma: no cover - depends on optional deps
+            self.get_logger().error(
+                "Falling back to disabled face capture: %s", exc
+            )
+            analyzer = _FallbackAnalyzer()
+
+        self.pipeline = FaceCapturePipeline(analyzer, config=config)
+        self.bridge = CvBridge()
+        self.publisher = self.create_publisher(
+            FaceSnapshotsMsg, "/altinet/face_snapshots", 10
+        )
+        self.track_subscription = self.create_subscription(
+            PersonTracksMsg,
+            "/altinet/person_tracks",
+            self._on_tracks,
+            10,
+        )
+        self.frame_subscription = self.create_subscription(
+            Image,
+            f"/altinet/camera/{self.room_id}",
+            self._on_image,
+            10,
+        )
+        self.service = self.create_service(
+            RequestFaceSnapshot,
+            "/altinet/request_face_snapshot",
+            self._handle_snapshot_request,
+        )
+        self.get_logger().info(
+            "Face capture node ready for room '%s'", self.room_id
+        )
+
+    # ------------------------------------------------------------------
+    # ROS Callbacks
+    # ------------------------------------------------------------------
+    def _on_image(self, msg: Image) -> None:
+        frame = self.bridge.imgmsg_to_cv2(msg, desired_encoding="bgr8")
+        timestamp = _ros_time_to_datetime(msg.header.stamp)
+        self.pipeline.add_frame(self.room_id, timestamp, frame)
+
+    def _on_tracks(self, msg: PersonTracksMsg) -> None:
+        timestamp = _ros_time_to_datetime(msg.header.stamp)
+        room_id = msg.room_id or self.room_id
+        tracks = []
+        for track_msg in msg.tracks:
+            track_stamp = getattr(track_msg, "header", None)
+            track_timestamp = _ros_time_to_datetime(track_stamp.stamp if track_stamp else None)
+            if track_stamp and getattr(track_stamp.stamp, "sec", 0) == 0 and getattr(
+                track_stamp.stamp, "nanosec", 0
+            ) == 0:
+                track_timestamp = timestamp
+            bbox = BoundingBox(track_msg.x, track_msg.y, track_msg.w, track_msg.h)
+            image_height = int(getattr(track_msg, "image_height", 0) or 0)
+            image_width = int(getattr(track_msg, "image_width", 0) or 0)
+            image_size = (image_height, image_width) if image_height and image_width else (0, 0)
+            tracks.append(
+                Track(
+                    track_id=int(track_msg.track_id),
+                    bbox=bbox,
+                    confidence=1.0,
+                    room_id=room_id,
+                    timestamp=track_timestamp,
+                    image_size=image_size,
+                )
+            )
+        if not tracks:
+            return
+        snapshots = self.pipeline.process_tracks(
+            room_id,
+            msg.header.frame_id,
+            timestamp,
+            tracks,
+        )
+        if not snapshots:
+            return
+        header = Header()
+        header.stamp = msg.header.stamp
+        header.frame_id = msg.header.frame_id
+        batch_msg = face_snapshots_to_msg(snapshots, header)
+        self.publisher.publish(batch_msg)
+        for snapshot in snapshots:
+            self.get_logger().info(
+                "Updated face snapshot for track %d in room '%s' (quality=%.3f)",
+                snapshot.track_id,
+                snapshot.room_id,
+                snapshot.quality.score,
+            )
+
+    def _handle_snapshot_request(self, request, response):
+        room_id = request.room_id or self.room_id
+        snapshot = self.pipeline.get_best_snapshot(room_id, int(request.track_id))
+        if snapshot is None:
+            response.success = False
+            return response
+        header = Header()
+        header.stamp = self.get_clock().now().to_msg()
+        header.frame_id = snapshot.frame_id
+        response.success = True
+        response.snapshot = face_snapshot_to_msg(snapshot, header)
+        return response
+
+
+__all__ = ["FaceCaptureNode"]
+
+
+def main(args=None):  # pragma: no cover - requires ROS runtime
+    if rclpy is None:
+        message = "ROS 2 dependencies could not be imported"
+        if _ROS_IMPORT_ERROR is not None:
+            message += f": {_ROS_IMPORT_ERROR}"
+        raise RuntimeError(message) from _ROS_IMPORT_ERROR
+    rclpy.init(args=args)
+    node = FaceCaptureNode()
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()

--- a/ros2_ws/src/altinet/altinet/srv/__init__.py
+++ b/ros2_ws/src/altinet/altinet/srv/__init__.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 try:
-    from altinet_interfaces.srv import CheckPersonIdentity, ManualLightOverride
+    from altinet_interfaces.srv import (
+        CheckPersonIdentity,
+        ManualLightOverride,
+        RequestFaceSnapshot,
+    )
 except ImportError as exc:  # pragma: no cover - requires ROS interfaces
     raise ImportError(
         "altinet_interfaces.srv could not be imported. "
         "Ensure the Altinet ROS 2 interfaces package is built and sourced."
     ) from exc
 
-__all__ = ["ManualLightOverride", "CheckPersonIdentity"]
+__all__ = ["ManualLightOverride", "CheckPersonIdentity", "RequestFaceSnapshot"]

--- a/ros2_ws/src/altinet/altinet/tests/test_face_capture.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_face_capture.py
@@ -1,0 +1,183 @@
+"""Tests for the face capture pipeline."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterable, List
+
+import numpy as np
+import pytest
+
+from altinet.utils.face_capture import FaceCaptureConfig, FaceCapturePipeline
+from altinet.utils.types import (
+    BoundingBox,
+    FaceCandidate,
+    FaceLandmarks,
+    FaceQuality,
+    Track,
+)
+
+
+class StubAnalyzer:
+    """Deterministic face analyzer used in tests."""
+
+    def __init__(self) -> None:
+        self._responses: List[List[FaceCandidate]] = []
+
+    def enqueue(self, candidates: Iterable[FaceCandidate]) -> None:
+        self._responses.append(list(candidates))
+
+    def detect(self, image: np.ndarray) -> List[FaceCandidate]:
+        if not self._responses:
+            return []
+        return self._responses.pop(0)
+
+
+def _quality_from_confidence(confidence: float) -> FaceQuality:
+    return FaceQuality(score=confidence, sharpness=confidence, brightness=0.5, pose=0.5)
+
+
+def _landmarks() -> FaceLandmarks:
+    return FaceLandmarks(
+        (
+            (10.0, 10.0),
+            (20.0, 10.0),
+            (15.0, 18.0),
+            (12.0, 24.0),
+            (18.0, 24.0),
+        )
+    )
+
+
+def _build_track(track_id: int, timestamp: datetime, bbox: BoundingBox) -> Track:
+    return Track(
+        track_id=track_id,
+        bbox=bbox,
+        confidence=0.9,
+        room_id="living_room",
+        timestamp=timestamp,
+        image_size=(120, 160),
+    )
+
+
+def test_pipeline_emits_snapshot_when_quality_exceeds_threshold() -> None:
+    analyzer = StubAnalyzer()
+    config = FaceCaptureConfig(
+        minimum_quality=0.5,
+        improvement_margin=0.05,
+        min_time_between_snapshots=0.0,
+        face_padding=0.0,
+    )
+    pipeline = FaceCapturePipeline(
+        analyzer,
+        config=config,
+        quality_evaluator=lambda image, candidate: _quality_from_confidence(
+            candidate.confidence
+        ),
+    )
+
+    timestamp = datetime(2024, 1, 1, 12, 0, 0)
+    frame = np.full((120, 160, 3), 128, dtype=np.uint8)
+    pipeline.add_frame("living_room", timestamp, frame)
+
+    candidate = FaceCandidate(
+        bbox=BoundingBox(6.0, 4.0, 24.0, 24.0),
+        landmarks=_landmarks(),
+        embedding=(0.1, 0.2, 0.3, 0.4),
+        confidence=0.9,
+    )
+    analyzer.enqueue([candidate])
+    track = _build_track(
+        7,
+        timestamp,
+        BoundingBox(20.0, 16.0, 48.0, 48.0),
+    )
+
+    snapshots = pipeline.process_tracks(
+        "living_room",
+        "camera_frame",
+        timestamp,
+        [track],
+    )
+    assert len(snapshots) == 1
+    snapshot = snapshots[0]
+    assert snapshot.track_id == 7
+    assert snapshot.room_id == "living_room"
+    assert snapshot.encoding == "bgr8"
+    assert snapshot.embedding == pytest.approx(candidate.embedding)
+    assert snapshot.bbox.x == pytest.approx(track.bbox.x + candidate.bbox.x)
+    assert snapshot.bbox.y == pytest.approx(track.bbox.y + candidate.bbox.y)
+    assert snapshot.face_image.shape[0] == pytest.approx(candidate.bbox.h, rel=0.05)
+    assert snapshot.face_image.shape[1] == pytest.approx(candidate.bbox.w, rel=0.05)
+
+
+def test_pipeline_requires_significant_quality_improvement() -> None:
+    analyzer = StubAnalyzer()
+    config = FaceCaptureConfig(
+        minimum_quality=0.55,
+        improvement_margin=0.05,
+        min_time_between_snapshots=0.0,
+        face_padding=0.0,
+    )
+    pipeline = FaceCapturePipeline(
+        analyzer,
+        config=config,
+        quality_evaluator=lambda image, candidate: _quality_from_confidence(
+            candidate.confidence
+        ),
+    )
+    base_bbox = BoundingBox(30.0, 20.0, 40.0, 40.0)
+    timestamp = datetime(2024, 1, 1, 9, 0, 0)
+    frame = np.full((140, 140, 3), 90, dtype=np.uint8)
+
+    pipeline.add_frame("living_room", timestamp, frame)
+    analyzer.enqueue(
+        [
+            FaceCandidate(
+                bbox=BoundingBox(8.0, 8.0, 24.0, 24.0),
+                landmarks=_landmarks(),
+                embedding=(0.5, 0.6, 0.7),
+                confidence=0.6,
+            )
+        ]
+    )
+    track = _build_track(3, timestamp, base_bbox)
+    first = pipeline.process_tracks("living_room", "camera_frame", timestamp, [track])
+    assert len(first) == 1
+    assert first[0].quality.score == pytest.approx(0.6)
+
+    timestamp2 = timestamp + timedelta(seconds=1)
+    pipeline.add_frame("living_room", timestamp2, frame)
+    analyzer.enqueue(
+        [
+            FaceCandidate(
+                bbox=BoundingBox(8.0, 8.0, 24.0, 24.0),
+                landmarks=_landmarks(),
+                embedding=(0.5, 0.6, 0.7),
+                confidence=0.62,
+            )
+        ]
+    )
+    track2 = _build_track(3, timestamp2, base_bbox)
+    second = pipeline.process_tracks("living_room", "camera_frame", timestamp2, [track2])
+    assert second == []
+
+    timestamp3 = timestamp2 + timedelta(seconds=1)
+    pipeline.add_frame("living_room", timestamp3, frame)
+    analyzer.enqueue(
+        [
+            FaceCandidate(
+                bbox=BoundingBox(8.0, 8.0, 24.0, 24.0),
+                landmarks=_landmarks(),
+                embedding=(0.5, 0.6, 0.7),
+                confidence=0.72,
+            )
+        ]
+    )
+    track3 = _build_track(3, timestamp3, base_bbox)
+    third = pipeline.process_tracks("living_room", "camera_frame", timestamp3, [track3])
+    assert len(third) == 1
+    assert third[0].quality.score == pytest.approx(0.72)
+    best = pipeline.get_best_snapshot("living_room", 3)
+    assert best is not None
+    assert best.quality.score == pytest.approx(0.72)

--- a/ros2_ws/src/altinet/altinet/utils/face_capture.py
+++ b/ros2_ws/src/altinet/altinet/utils/face_capture.py
@@ -1,0 +1,352 @@
+"""Face capture pipeline for extracting high-quality face snapshots."""
+
+from __future__ import annotations
+
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Callable, Dict, Iterable, List, Optional, Tuple
+
+import numpy as np
+
+from .types import (
+    BoundingBox,
+    FaceCandidate,
+    FaceLandmarks,
+    FaceQuality,
+    FaceSnapshot,
+    Track,
+)
+
+QualityEvaluator = Callable[[np.ndarray, FaceCandidate], FaceQuality]
+
+
+@dataclass
+class FaceCaptureConfig:
+    """Configuration parameters governing the face capture pipeline."""
+
+    minimum_quality: float = 0.6
+    improvement_margin: float = 0.05
+    min_time_between_snapshots: float = 2.0
+    frame_history: int = 45
+    face_padding: float = 0.15
+    frame_tolerance_s: float = 0.1
+
+
+class FaceCapturePipeline:
+    """Match tracked people with face snapshots produced by a detector."""
+
+    def __init__(
+        self,
+        analyzer,
+        config: Optional[FaceCaptureConfig] = None,
+        quality_evaluator: Optional[QualityEvaluator] = None,
+    ) -> None:
+        self.analyzer = analyzer or _NoOpAnalyzer()
+        self.config = config or FaceCaptureConfig()
+        self.quality_evaluator = quality_evaluator or _default_quality_evaluator
+        self._frames: Dict[str, OrderedDict[datetime, np.ndarray]] = {}
+        self._best_snapshots: Dict[Tuple[str, int], FaceSnapshot] = {}
+        self._last_publish_time: Dict[Tuple[str, int], datetime] = {}
+
+    # ------------------------------------------------------------------
+    # Frame management
+    # ------------------------------------------------------------------
+    def add_frame(self, room_id: str, timestamp: datetime, frame: np.ndarray) -> None:
+        """Store a frame for later association with track updates."""
+
+        if not isinstance(frame, np.ndarray):
+            raise TypeError("frame must be a numpy.ndarray")
+        buffer = self._frames.setdefault(room_id, OrderedDict())
+        buffer[timestamp] = np.ascontiguousarray(frame)
+        while len(buffer) > self.config.frame_history:
+            buffer.popitem(last=False)
+
+    # ------------------------------------------------------------------
+    # Track processing
+    # ------------------------------------------------------------------
+    def process_tracks(
+        self,
+        room_id: str,
+        frame_id: str,
+        timestamp: datetime,
+        tracks: Iterable[Track],
+    ) -> List[FaceSnapshot]:
+        """Process ``tracks`` observed in ``room_id`` at ``timestamp``."""
+
+        frame = self._lookup_frame(room_id, timestamp)
+        if frame is None:
+            return []
+        results: List[FaceSnapshot] = []
+        image_height, image_width = frame.shape[:2]
+        for track in tracks:
+            if track.room_id and track.room_id != room_id:
+                continue
+            crop_bbox = _expand_bbox(
+                track.bbox,
+                self.config.face_padding,
+                float(image_width),
+                float(image_height),
+            )
+            crop = _crop(frame, crop_bbox)
+            if crop is None:
+                continue
+            candidates = list(self.analyzer.detect(crop))
+            if not candidates:
+                continue
+            best_snapshot: Optional[FaceSnapshot] = None
+            best_quality: Optional[FaceQuality] = None
+            for candidate in candidates:
+                translated = _translate_bbox(candidate.bbox, crop_bbox, frame.shape[:2])
+                if translated is None:
+                    continue
+                face_patch = _crop(frame, translated)
+                if face_patch is None:
+                    continue
+                quality = self.quality_evaluator(face_patch, candidate)
+                snapshot = FaceSnapshot(
+                    track_id=track.track_id,
+                    room_id=room_id,
+                    timestamp=track.timestamp,
+                    frame_id=frame_id,
+                    bbox=translated,
+                    quality=quality,
+                    landmarks=candidate.landmarks,
+                    embedding=tuple(float(x) for x in candidate.embedding),
+                    face_image=np.ascontiguousarray(face_patch),
+                    encoding="bgr8",
+                )
+                if best_quality is None or quality.score > best_quality.score:
+                    best_quality = quality
+                    best_snapshot = snapshot
+            if best_snapshot is None:
+                continue
+            if self._should_publish(best_snapshot):
+                results.append(best_snapshot)
+        return results
+
+    def get_best_snapshot(self, room_id: str, track_id: int) -> Optional[FaceSnapshot]:
+        """Return the best known snapshot for ``track_id`` in ``room_id``."""
+
+        return self._best_snapshots.get((room_id, track_id))
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _lookup_frame(self, room_id: str, timestamp: datetime) -> Optional[np.ndarray]:
+        buffer = self._frames.get(room_id)
+        if not buffer:
+            return None
+        frame = buffer.get(timestamp)
+        if frame is not None:
+            return frame
+        tolerance = max(self.config.frame_tolerance_s, 0.0)
+        if tolerance <= 0.0:
+            return None
+        best_key = None
+        best_delta = float("inf")
+        for key in buffer.keys():
+            delta = abs((timestamp - key).total_seconds())
+            if delta < best_delta:
+                best_delta = delta
+                best_key = key
+        if best_key is None or best_delta > tolerance:
+            return None
+        return buffer[best_key]
+
+    def _should_publish(self, snapshot: FaceSnapshot) -> bool:
+        key = (snapshot.room_id, snapshot.track_id)
+        best = self._best_snapshots.get(key)
+        quality = snapshot.quality.score
+        min_quality = self.config.minimum_quality
+        if best is None:
+            if quality >= min_quality and self._cadence_allows(key, snapshot.timestamp):
+                self._best_snapshots[key] = snapshot
+                self._last_publish_time[key] = snapshot.timestamp
+                return True
+            if quality > (best.quality.score if best else float("-inf")):
+                self._best_snapshots[key] = snapshot
+            return False
+
+        improvement = quality - best.quality.score
+        should_update_best = improvement > 0.0
+        if quality < min_quality or improvement < self.config.improvement_margin:
+            if should_update_best:
+                self._best_snapshots[key] = snapshot
+            return False
+        if not self._cadence_allows(key, snapshot.timestamp):
+            if should_update_best:
+                self._best_snapshots[key] = snapshot
+            return False
+        self._best_snapshots[key] = snapshot
+        self._last_publish_time[key] = snapshot.timestamp
+        return True
+
+    def _cadence_allows(self, key: Tuple[str, int], timestamp: datetime) -> bool:
+        interval = max(self.config.min_time_between_snapshots, 0.0)
+        if interval <= 0.0:
+            return True
+        last_time = self._last_publish_time.get(key)
+        if last_time is None:
+            return True
+        return (timestamp - last_time).total_seconds() >= interval
+
+
+class InsightFaceAnalyzer:
+    """Adapter around :mod:`insightface` providing ``FaceCandidate`` objects."""
+
+    def __init__(
+        self,
+        model_name: str = "buffalo_l",
+        model_root: Optional[str] = None,
+        det_size: Tuple[int, int] = (640, 640),
+        ctx_id: int = 0,
+    ) -> None:
+        try:  # pragma: no cover - optional dependency
+            from insightface.app import FaceAnalysis
+        except ImportError as exc:  # pragma: no cover - executed when dependency missing
+            raise RuntimeError(
+                "insightface is required to use InsightFaceAnalyzer"
+            ) from exc
+        self._app = FaceAnalysis(name=model_name, root=model_root)
+        self._app.prepare(ctx_id=ctx_id, det_size=det_size)
+
+    def detect(self, image: np.ndarray) -> List[FaceCandidate]:  # pragma: no cover - thin wrapper
+        faces = self._app.get(image)
+        candidates: List[FaceCandidate] = []
+        for face in faces:
+            bbox = getattr(face, "bbox", None)
+            kps = getattr(face, "kps", None)
+            embedding = getattr(face, "embedding", None)
+            det_score = float(getattr(face, "det_score", 0.0))
+            if bbox is None or kps is None:
+                continue
+            x1, y1, x2, y2 = [float(value) for value in bbox]
+            width = max(x2 - x1, 0.0)
+            height = max(y2 - y1, 0.0)
+            try:
+                landmarks = FaceLandmarks(
+                    tuple((float(point[0]), float(point[1])) for point in kps)
+                )
+            except ValueError:
+                continue
+            embedding_values: Tuple[float, ...]
+            if embedding is None:
+                embedding_values = tuple()
+            else:
+                embedding_array = np.asarray(embedding).astype(np.float32).flatten()
+                embedding_values = tuple(float(value) for value in embedding_array)
+            candidates.append(
+                FaceCandidate(
+                    bbox=BoundingBox(x1, y1, width, height),
+                    landmarks=landmarks,
+                    embedding=embedding_values,
+                    confidence=det_score,
+                )
+            )
+        return candidates
+
+
+class _NoOpAnalyzer:
+    """Fallback analyzer that never produces faces."""
+
+    def detect(self, image: np.ndarray) -> List[FaceCandidate]:  # pragma: no cover - trivial
+        return []
+
+
+def _expand_bbox(
+    bbox: BoundingBox,
+    padding_ratio: float,
+    image_width: float,
+    image_height: float,
+) -> BoundingBox:
+    pad_w = max(bbox.w * padding_ratio, 0.0)
+    pad_h = max(bbox.h * padding_ratio, 0.0)
+    x = max(bbox.x - pad_w / 2.0, 0.0)
+    y = max(bbox.y - pad_h / 2.0, 0.0)
+    w = min(bbox.w + pad_w, image_width - x)
+    h = min(bbox.h + pad_h, image_height - y)
+    return BoundingBox(x, y, w, h)
+
+
+def _translate_bbox(
+    local_bbox: BoundingBox, offset: BoundingBox, image_size: Tuple[int, int]
+) -> Optional[BoundingBox]:
+    x = offset.x + local_bbox.x
+    y = offset.y + local_bbox.y
+    w = local_bbox.w
+    h = local_bbox.h
+    clipped = _clip_bbox(BoundingBox(x, y, w, h), image_size)
+    return clipped
+
+
+def _clip_bbox(bbox: BoundingBox, image_size: Tuple[int, int]) -> Optional[BoundingBox]:
+    height, width = image_size
+    x1 = max(bbox.x, 0.0)
+    y1 = max(bbox.y, 0.0)
+    x2 = min(bbox.x + bbox.w, float(width))
+    y2 = min(bbox.y + bbox.h, float(height))
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return BoundingBox(x1, y1, x2 - x1, y2 - y1)
+
+
+def _crop(image: np.ndarray, bbox: BoundingBox) -> Optional[np.ndarray]:
+    x1 = int(round(bbox.x))
+    y1 = int(round(bbox.y))
+    x2 = int(round(bbox.x + bbox.w))
+    y2 = int(round(bbox.y + bbox.h))
+    if x2 <= x1 or y2 <= y1:
+        return None
+    height, width = image.shape[:2]
+    x1 = max(x1, 0)
+    y1 = max(y1, 0)
+    x2 = min(x2, width)
+    y2 = min(y2, height)
+    if x2 <= x1 or y2 <= y1:
+        return None
+    return np.ascontiguousarray(image[y1:y2, x1:x2])
+
+
+def _default_quality_evaluator(
+    face_image: np.ndarray, candidate: FaceCandidate
+) -> FaceQuality:
+    if face_image.size == 0:
+        return FaceQuality(score=0.0, sharpness=0.0, brightness=0.0, pose=0.0)
+    image = face_image.astype(np.float32)
+    if image.ndim == 3:
+        gray = image.mean(axis=2)
+    else:
+        gray = image
+    gy, gx = np.gradient(gray)
+    magnitude = np.sqrt(gx**2 + gy**2)
+    sharpness_raw = float(magnitude.mean())
+    sharpness = float(np.tanh(sharpness_raw / 50.0))
+    max_value = 255.0 if face_image.dtype != np.float32 else 1.0
+    brightness = float(np.clip(gray.mean() / max_value, 0.0, 1.0))
+    pose = _estimate_pose(candidate.landmarks)
+    score = float(
+        0.5 * candidate.confidence + 0.3 * sharpness + 0.15 * brightness + 0.05 * pose
+    )
+    return FaceQuality(score=score, sharpness=sharpness, brightness=brightness, pose=pose)
+
+
+def _estimate_pose(landmarks: FaceLandmarks) -> float:
+    try:
+        left_eye = landmarks.points[0]
+        right_eye = landmarks.points[1]
+    except (IndexError, TypeError):
+        return 0.0
+    horizontal = abs(right_eye[0] - left_eye[0])
+    vertical = abs(right_eye[1] - left_eye[1])
+    if horizontal <= 0.0:
+        return 0.0
+    tilt_ratio = vertical / horizontal
+    return float(max(0.0, 1.0 - min(tilt_ratio, 1.0)))
+
+
+__all__ = [
+    "FaceCaptureConfig",
+    "FaceCapturePipeline",
+    "InsightFaceAnalyzer",
+]

--- a/ros2_ws/src/altinet/altinet/utils/types.py
+++ b/ros2_ws/src/altinet/altinet/utils/types.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Dict, List, Tuple
 
+import numpy as np
+
 
 @dataclass
 class BoundingBox:
@@ -89,6 +91,79 @@ class Track:
 
 
 @dataclass
+class FaceLandmarks:
+    """Five-point facial landmarks."""
+
+    points: Tuple[Tuple[float, float], ...]
+
+    def __post_init__(self) -> None:
+        if len(self.points) != 5:
+            raise ValueError("FaceLandmarks requires exactly five points")
+
+    def flatten(self) -> Tuple[float, ...]:
+        """Return landmarks as a flat ``(x1, y1, ..., x5, y5)`` tuple."""
+
+        flattened: List[float] = []
+        for x, y in self.points:
+            flattened.extend([float(x), float(y)])
+        return tuple(flattened)
+
+
+@dataclass
+class FaceQuality:
+    """Aggregate quality metrics for a face snapshot."""
+
+    score: float
+    sharpness: float
+    brightness: float
+    pose: float
+
+
+@dataclass
+class FaceCandidate:
+    """Face candidate returned by an alignment/embedding model."""
+
+    bbox: BoundingBox
+    landmarks: FaceLandmarks
+    embedding: Tuple[float, ...]
+    confidence: float
+
+
+@dataclass
+class FaceSnapshot:
+    """Best-quality face snapshot aligned with a tracked person."""
+
+    track_id: int
+    room_id: str
+    timestamp: datetime
+    frame_id: str
+    bbox: BoundingBox
+    quality: FaceQuality
+    landmarks: FaceLandmarks
+    embedding: Tuple[float, ...]
+    face_image: np.ndarray
+    encoding: str = "rgb8"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.face_image, np.ndarray):
+            raise TypeError("face_image must be a numpy.ndarray")
+        if self.face_image.ndim not in (2, 3):
+            raise ValueError("face_image must be 2D or 3D array")
+
+    @property
+    def face_height(self) -> int:
+        """Height of the aligned face image."""
+
+        return int(self.face_image.shape[0])
+
+    @property
+    def face_width(self) -> int:
+        """Width of the aligned face image."""
+
+        return int(self.face_image.shape[1])
+
+
+@dataclass
 class RoomPresence:
     """Presence summary for a room."""
 
@@ -128,6 +203,10 @@ __all__ = [
     "BoundingBox",
     "Detection",
     "Track",
+    "FaceLandmarks",
+    "FaceQuality",
+    "FaceCandidate",
+    "FaceSnapshot",
     "RoomPresence",
     "Event",
     "LightCommand",

--- a/ros2_ws/src/altinet/setup.py
+++ b/ros2_ws/src/altinet/setup.py
@@ -215,6 +215,7 @@ setup(
             'camera_node = altinet.nodes.camera_node:main',
             'camera_viewer_node = altinet.nodes.camera_viewer_node:main',
             'detector_node = altinet.nodes.detector_node:main',
+            'face_capture_node = altinet.nodes.face_capture_node:main',
             'identity_node = altinet.nodes.identity_node:main',
             'tracker_node = altinet.nodes.tracker_node:main',
             'event_manager_node = altinet.nodes.event_manager_node:main',

--- a/ros2_ws/src/altinet_interfaces/CMakeLists.txt
+++ b/ros2_ws/src/altinet_interfaces/CMakeLists.txt
@@ -12,11 +12,14 @@ set(msg_files
   "msg/PersonTrack.msg"
   "msg/PersonTracks.msg"
   "msg/RoomPresence.msg"
+  "msg/FaceSnapshot.msg"
+  "msg/FaceSnapshots.msg"
 )
 
 set(srv_files
   "srv/ManualLightOverride.srv"
   "srv/CheckPersonIdentity.srv"
+  "srv/RequestFaceSnapshot.srv"
 )
 
 rosidl_generate_interfaces(${PROJECT_NAME}

--- a/ros2_ws/src/altinet_interfaces/msg/FaceSnapshot.msg
+++ b/ros2_ws/src/altinet_interfaces/msg/FaceSnapshot.msg
@@ -1,0 +1,18 @@
+# Face snapshot captured from a tracked person.
+std_msgs/Header header
+string room_id
+int32 track_id
+float32 x
+float32 y
+float32 w
+float32 h
+float32 quality_score
+float32 sharpness
+float32 brightness
+float32 pose_score
+float32[10] landmarks
+float32[] embedding
+uint32 face_width
+uint32 face_height
+string face_encoding
+uint8[] face_data

--- a/ros2_ws/src/altinet_interfaces/msg/FaceSnapshots.msg
+++ b/ros2_ws/src/altinet_interfaces/msg/FaceSnapshots.msg
@@ -1,0 +1,4 @@
+# Batched face snapshots captured from tracked people.
+std_msgs/Header header
+string room_id
+FaceSnapshot[] snapshots

--- a/ros2_ws/src/altinet_interfaces/srv/RequestFaceSnapshot.srv
+++ b/ros2_ws/src/altinet_interfaces/srv/RequestFaceSnapshot.srv
@@ -1,0 +1,5 @@
+string room_id
+int32 track_id
+---
+bool success
+FaceSnapshot snapshot


### PR DESCRIPTION
## Summary
- add FaceSnapshot messages and a RequestFaceSnapshot service for face capture support
- implement the face capture pipeline plus ROS conversions and node to publish aligned snapshots
- wire the new node into the launch system and provide tests covering quality gating logic

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest ros2_ws/src/altinet/altinet/tests/test_face_capture.py

------
https://chatgpt.com/codex/tasks/task_e_68d34eb8a3e0832f8d9cec00018cb051