### PR TITLE
Enhance identity service to use face embeddings

### DIFF
--- a/ros2_ws/src/altinet/altinet/nodes/detector_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/detector_node.py
@@ -192,6 +192,12 @@ class DetectorNode(Node):  # pragma: no cover - requires ROS runtime
         image_height, image_width = detection.image_size
         request.image_width = int(image_width)
         request.image_height = int(image_height)
+        if hasattr(request, "include_embedding_info"):
+            request.include_embedding_info = True
+        elif hasattr(request, "return_embedding_id"):
+            request.return_embedding_id = True
+        if hasattr(request, "include_embedding_diagnostics"):
+            request.include_embedding_diagnostics = True
 
         future = self.identity_client.call_async(request)
         future.add_done_callback(partial(self._log_identity_result, detection=detection))

--- a/ros2_ws/src/altinet/altinet/nodes/identity_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/identity_node.py
@@ -2,8 +2,18 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Optional
 
+import numpy as np
+
+from ..utils.face_identity import (
+    FaceIdentityConfig,
+    FaceIdentityResolver,
+    FaceSnapshot,
+    FaceSnapshotCache,
+    load_face_index,
+)
 from ..utils.identity import (
     IdentityClassificationConfig,
     IdentityClassifier,
@@ -16,11 +26,21 @@ try:  # pragma: no cover - optional when ROS 2 is unavailable
     import rclpy
     from rclpy.node import Node
     from altinet.srv import CheckPersonIdentity
+    try:  # pragma: no cover - optional dependency
+        from altinet_interfaces.msg import FaceSnapshot as FaceSnapshotMsg
+    except ImportError:  # pragma: no cover - executed when interfaces unavailable
+        FaceSnapshotMsg = None  # type: ignore
+    try:  # pragma: no cover - optional dependency
+        from altinet_interfaces.srv import GetFaceSnapshot
+    except ImportError:  # pragma: no cover - executed when interfaces unavailable
+        GetFaceSnapshot = None  # type: ignore
 except ImportError as exc:  # pragma: no cover - executed during tests
     _ROS_IMPORT_ERROR = exc
     rclpy = None
     Node = object  # type: ignore
     CheckPersonIdentity = None
+    FaceSnapshotMsg = None  # type: ignore
+    GetFaceSnapshot = None  # type: ignore
 
 
 class IdentityNode(Node):  # pragma: no cover - requires ROS runtime
@@ -36,6 +56,16 @@ class IdentityNode(Node):  # pragma: no cover - requires ROS runtime
         self.declare_parameter("user_confidence_bonus", 0.2)
         self.declare_parameter("guest_confidence_scale", 0.6)
         self.declare_parameter("unknown_confidence_scale", 0.4)
+        self.declare_parameter("face_index_path", "")
+        self.declare_parameter("face_index_metadata_path", "")
+        self.declare_parameter("face_snapshot_topic", "/altinet/face_snapshot")
+        self.declare_parameter("face_snapshot_service", "/altinet/get_face_snapshot")
+        self.declare_parameter("snapshot_cache_ttl_sec", 5.0)
+        self.declare_parameter("user_similarity_threshold", 0.75)
+        self.declare_parameter("guest_similarity_threshold", 0.6)
+        self.declare_parameter("unknown_label", "unknown")
+        self.declare_parameter("fallback_to_heuristic_for_unknown", False)
+        self.declare_parameter("face_snapshot_timeout", 0.5)
 
         config = IdentityClassificationConfig(
             user_min_area_ratio=float(self.get_parameter("user_min_area_ratio").value),
@@ -53,6 +83,65 @@ class IdentityNode(Node):  # pragma: no cover - requires ROS runtime
             ),
         )
         self.classifier = IdentityClassifier(config)
+
+        cache_ttl = float(self.get_parameter("snapshot_cache_ttl_sec").value)
+        self._snapshot_cache = FaceSnapshotCache(cache_ttl)
+        face_index_path = Path(str(self.get_parameter("face_index_path").value or ""))
+        metadata_path_param = str(self.get_parameter("face_index_metadata_path").value or "")
+        metadata_path = Path(metadata_path_param) if metadata_path_param else None
+        face_index = None
+        if face_index_path and face_index_path.exists():
+            try:
+                face_index = load_face_index(face_index_path, metadata_path=metadata_path)
+                if face_index is None:
+                    self.get_logger().warn(
+                        "Face index configuration empty; falling back to heuristics"
+                    )
+            except Exception as exc:  # pragma: no cover - logging best effort
+                self.get_logger().error(
+                    f"Failed to load face index from '{face_index_path}': {exc}"
+                )
+
+        identity_config = FaceIdentityConfig(
+            user_similarity_threshold=float(
+                self.get_parameter("user_similarity_threshold").value
+            ),
+            guest_similarity_threshold=float(
+                self.get_parameter("guest_similarity_threshold").value
+            ),
+            unknown_label=str(self.get_parameter("unknown_label").value),
+            fallback_to_heuristic_for_unknown=bool(
+                self.get_parameter("fallback_to_heuristic_for_unknown").value
+            ),
+        )
+        self._snapshot_timeout = float(self.get_parameter("face_snapshot_timeout").value)
+
+        self._resolver = FaceIdentityResolver(
+            classifier=self.classifier,
+            index=face_index,
+            cache=self._snapshot_cache,
+            config=identity_config,
+            snapshot_fetcher=self._request_snapshot_via_service,
+        )
+
+        snapshot_topic = str(self.get_parameter("face_snapshot_topic").value)
+        self._face_subscription = None
+        if FaceSnapshotMsg is not None and snapshot_topic:
+            self._face_subscription = self.create_subscription(
+                FaceSnapshotMsg,
+                snapshot_topic,
+                self._on_face_snapshot,
+                10,
+            )
+
+        self._snapshot_client = None
+        if GetFaceSnapshot is not None:
+            snapshot_service = str(self.get_parameter("face_snapshot_service").value)
+            if snapshot_service:
+                self._snapshot_client = self.create_client(
+                    GetFaceSnapshot,
+                    snapshot_service,
+                )
 
         self.service = self.create_service(
             CheckPersonIdentity,
@@ -77,12 +166,101 @@ class IdentityNode(Node):  # pragma: no cover - requires ROS runtime
             area_ratio=area_ratio,
             detection_confidence=float(request.detection_confidence),
         )
-        result = self.classifier.classify(observation)
+        decision = self._resolver.resolve(observation, observation.track_id)
+        result = decision.result
         response.label = result.label
         response.is_user = result.is_user
         response.confidence = float(result.confidence)
         response.reason = result.reason
+        if hasattr(response, "embedding_id") and decision.embedding_id is not None:
+            response.embedding_id = decision.embedding_id
+        if hasattr(response, "embedding_similarity") and decision.similarity is not None:
+            response.embedding_similarity = float(decision.similarity)
+        if hasattr(response, "snapshot_age") and decision.snapshot_age is not None:
+            response.snapshot_age = float(decision.snapshot_age)
+        if hasattr(response, "used_face_embedding"):
+            response.used_face_embedding = not decision.used_fallback
         return response
+
+    def _on_face_snapshot(self, msg) -> None:
+        try:
+            embedding_data = None
+            if hasattr(msg, "embedding"):
+                embedding = getattr(msg, "embedding")
+                if isinstance(embedding, np.ndarray):
+                    embedding_data = embedding.astype(np.float32)
+                elif hasattr(embedding, "data"):
+                    embedding_data = np.asarray(embedding.data, dtype=np.float32)
+                else:
+                    embedding_data = np.asarray(list(embedding), dtype=np.float32)
+            if embedding_data is None or embedding_data.size == 0:
+                return
+            track_id = int(getattr(msg, "track_id", -1))
+            embedding_id = getattr(msg, "embedding_id", None)
+            quality = getattr(msg, "quality", None)
+            snapshot = FaceSnapshot(
+                track_id=track_id,
+                embedding=embedding_data,
+                embedding_id=str(embedding_id) if embedding_id not in {None, ""} else None,
+                quality=float(quality) if isinstance(quality, (float, int)) else None,
+            )
+            self._resolver.update_snapshot(snapshot)
+        except Exception as exc:  # pragma: no cover - logging best effort
+            self.get_logger().warn(f"Failed to process face snapshot: {exc}")
+
+    def _request_snapshot_via_service(self, track_id: int) -> Optional[FaceSnapshot]:
+        if self._snapshot_client is None:
+            return None
+        if not self._snapshot_client.service_is_ready():
+            return None
+        try:
+            request = self._snapshot_client.srv_type.Request()  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - best effort for compatibility
+            request = None
+        if request is None:
+            return None
+        if hasattr(request, "track_id"):
+            request.track_id = int(track_id)
+        future = self._snapshot_client.call_async(request)
+        if self._snapshot_timeout > 0.0:
+            rclpy.spin_until_future_complete(
+                self,
+                future,
+                timeout_sec=self._snapshot_timeout,
+            )
+        if not future.done():
+            return None
+        try:
+            response = future.result()
+        except Exception:  # pragma: no cover - best effort logging
+            return None
+        snapshot_msg = None
+        if hasattr(response, "snapshot"):
+            snapshot_msg = response.snapshot
+        elif hasattr(response, "snapshots") and response.snapshots:
+            snapshot_msg = response.snapshots[0]
+        if snapshot_msg is None:
+            return None
+        try:
+            embedding = getattr(snapshot_msg, "embedding")
+            if isinstance(embedding, np.ndarray):
+                vector = embedding.astype(np.float32)
+            elif hasattr(embedding, "data"):
+                vector = np.asarray(embedding.data, dtype=np.float32)
+            else:
+                vector = np.asarray(list(embedding), dtype=np.float32)
+            if vector.size == 0:
+                return None
+            embedding_id = getattr(snapshot_msg, "embedding_id", None)
+            quality = getattr(snapshot_msg, "quality", None)
+            return FaceSnapshot(
+                track_id=int(getattr(snapshot_msg, "track_id", track_id)),
+                embedding=vector,
+                embedding_id=str(embedding_id) if embedding_id not in {None, ""} else None,
+                quality=float(quality) if isinstance(quality, (float, int)) else None,
+            )
+        except Exception:  # pragma: no cover - best effort logging
+            return None
 
 
 __all__ = ["IdentityNode"]

--- a/ros2_ws/src/altinet/altinet/tests/test_identity.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_identity.py
@@ -1,5 +1,6 @@
 """Tests for the identity classification helpers."""
 
+import numpy as np
 import pytest
 
 from altinet.utils.identity import (
@@ -7,6 +8,13 @@ from altinet.utils.identity import (
     IdentityClassifier,
     IdentityObservation,
     compute_area_ratio,
+)
+from altinet.utils.face_identity import (
+    FaceEmbeddingIndex,
+    FaceIdentityConfig,
+    FaceIdentityResolver,
+    FaceSnapshot,
+    FaceSnapshotCache,
 )
 
 
@@ -66,3 +74,122 @@ def test_compute_area_ratio_handles_invalid_dimensions():
     assert compute_area_ratio(10.0, 20.0, 100, 0) == 0.0
     ratio = compute_area_ratio(10.0, 20.0, 100, 200)
     assert ratio == pytest.approx((10.0 * 20.0) / (100 * 200))
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self._now = 0.0
+
+    def now(self) -> float:
+        return self._now
+
+    def advance(self, seconds: float) -> None:
+        self._now += float(seconds)
+
+
+def make_face_resolver(
+    embeddings: np.ndarray,
+    labels,
+    *,
+    is_user_map=None,
+    cache_ttl: float = 5.0,
+    fetcher=None,
+    config: FaceIdentityConfig | None = None,
+):
+    clock = FakeClock()
+    cache = FaceSnapshotCache(cache_ttl, clock=clock.now)
+    index = FaceEmbeddingIndex(embeddings, labels, label_is_user=is_user_map)
+    classifier = IdentityClassifier(IdentityClassificationConfig(user_min_area_ratio=0.02))
+    resolver = FaceIdentityResolver(
+        classifier=classifier,
+        index=index,
+        cache=cache,
+        config=config
+        or FaceIdentityConfig(
+            user_similarity_threshold=0.7,
+            guest_similarity_threshold=0.6,
+            unknown_label="unknown",
+            fallback_to_heuristic_for_unknown=False,
+        ),
+        snapshot_fetcher=fetcher,
+    )
+    return resolver, cache, clock
+
+
+def test_face_identity_respects_similarity_thresholds():
+    embeddings = np.array([[1.0, 0.0], [0.0, 1.0]], dtype=np.float32)
+    labels = ["resident", "guest_1"]
+    resolver, cache, _ = make_face_resolver(
+        embeddings,
+        labels,
+        is_user_map={"resident": True, "guest_1": False},
+        config=FaceIdentityConfig(
+            user_similarity_threshold=0.8,
+            guest_similarity_threshold=0.6,
+            unknown_label="unknown",
+            fallback_to_heuristic_for_unknown=False,
+        ),
+    )
+    cache.update(FaceSnapshot(track_id=7, embedding=np.array([1.0, 0.0], dtype=np.float32)))
+    observation = make_observation(0.02, 0.9)
+
+    decision = resolver.resolve(observation, track_id=7)
+
+    assert decision.result.label == "resident"
+    assert decision.result.is_user is True
+    assert decision.result.confidence == pytest.approx(1.0)
+    assert decision.embedding_id == "resident"
+    assert decision.used_fallback is False
+
+
+def test_face_identity_falls_back_to_heuristic_when_snapshot_missing():
+    embeddings = np.array([[1.0, 0.0]], dtype=np.float32)
+    labels = ["resident"]
+    resolver, _cache, _ = make_face_resolver(
+        embeddings,
+        labels,
+        is_user_map={"resident": True},
+    )
+    observation = make_observation(0.005, 0.9)
+
+    decision = resolver.resolve(observation, track_id=42)
+
+    assert decision.used_fallback is True
+    assert decision.result.label == "guest"
+    assert "No face embedding" in decision.result.reason
+
+
+def test_face_snapshot_cache_expires_and_requests_refresh():
+    embeddings = np.array([[0.0, 1.0]], dtype=np.float32)
+    labels = ["guest"]
+    fetch_calls: list[int] = []
+
+    def fetcher(track_id: int):
+        fetch_calls.append(track_id)
+        return FaceSnapshot(track_id=track_id, embedding=np.array([0.0, 1.0], dtype=np.float32))
+
+    resolver, cache, clock = make_face_resolver(
+        embeddings,
+        labels,
+        is_user_map={"guest": False},
+        cache_ttl=1.0,
+        fetcher=fetcher,
+        config=FaceIdentityConfig(
+            user_similarity_threshold=0.7,
+            guest_similarity_threshold=0.5,
+            unknown_label="unknown",
+            fallback_to_heuristic_for_unknown=False,
+        ),
+    )
+    cache.update(FaceSnapshot(track_id=3, embedding=np.array([0.0, 1.0], dtype=np.float32)))
+    observation = make_observation(0.02, 0.8)
+
+    decision_first = resolver.resolve(observation, track_id=3)
+    assert decision_first.result.label == "guest"
+    assert not fetch_calls
+
+    clock.advance(2.0)
+    decision_second = resolver.resolve(observation, track_id=3)
+
+    assert fetch_calls == [3]
+    assert decision_second.result.label == "guest"

--- a/ros2_ws/src/altinet/altinet/utils/face_identity.py
+++ b/ros2_ws/src/altinet/altinet/utils/face_identity.py
@@ -1,0 +1,399 @@
+"""Face recognition utilities used by the identity service."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import numpy as np
+
+from .config import load_file
+
+
+ArrayLike = Sequence[float] | np.ndarray
+
+
+@dataclass
+class FaceSnapshot:
+    """Container for a normalised face embedding tied to a track."""
+
+    track_id: int
+    embedding: np.ndarray
+    embedding_id: Optional[str] = None
+    quality: Optional[float] = None
+
+    def __post_init__(self) -> None:
+        vector = np.asarray(self.embedding, dtype=np.float32)
+        if vector.ndim != 1:
+            raise ValueError("FaceSnapshot embedding must be a 1D vector")
+        norm = float(np.linalg.norm(vector))
+        if not math.isfinite(norm) or norm <= 0.0:
+            self.embedding = np.zeros_like(vector)
+        else:
+            self.embedding = vector / norm
+
+
+class FaceSnapshotCache:
+    """LRU-style cache storing the most recent snapshot per track."""
+
+    def __init__(
+        self,
+        max_age_sec: float,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.max_age_sec = max(0.0, float(max_age_sec))
+        self._clock = clock or time.monotonic
+        self._entries: Dict[int, Tuple[FaceSnapshot, float]] = {}
+
+    def update(self, snapshot: FaceSnapshot) -> None:
+        """Store ``snapshot`` and mark it as freshly seen."""
+
+        self._entries[int(snapshot.track_id)] = (snapshot, self._clock())
+
+    def get(self, track_id: int) -> Tuple[Optional[FaceSnapshot], Optional[float]]:
+        """Return the cached snapshot for ``track_id`` and its age."""
+
+        entry = self._entries.get(int(track_id))
+        if entry is None:
+            return None, None
+        snapshot, timestamp = entry
+        age = self._clock() - timestamp
+        if self.max_age_sec > 0.0 and age > self.max_age_sec:
+            self._entries.pop(int(track_id), None)
+            return None, None
+        return snapshot, max(0.0, age)
+
+    def prune(self) -> None:
+        """Remove expired entries eagerly."""
+
+        expired: List[int] = []
+        now = self._clock()
+        if self.max_age_sec <= 0.0:
+            return
+        for track_id, (_, stored) in self._entries.items():
+            if now - stored > self.max_age_sec:
+                expired.append(track_id)
+        for track_id in expired:
+            self._entries.pop(track_id, None)
+
+
+@dataclass
+class FaceMatch:
+    """Represents a similarity match returned by :class:`FaceEmbeddingIndex`."""
+
+    label: str
+    similarity: float
+    embedding_id: Optional[str] = None
+    index: int | None = None
+
+
+class FaceEmbeddingIndex:
+    """Simple cosine-similarity index backed by NumPy arrays."""
+
+    def __init__(
+        self,
+        embeddings: ArrayLike,
+        labels: Sequence[str],
+        *,
+        embedding_ids: Sequence[str] | None = None,
+        label_is_user: Mapping[str, bool] | None = None,
+    ) -> None:
+        vectors = np.asarray(embeddings, dtype=np.float32)
+        if vectors.ndim != 2:
+            raise ValueError("embeddings must be a 2D array")
+        if len(labels) != vectors.shape[0]:
+            raise ValueError("labels length must match number of embeddings")
+        norms = np.linalg.norm(vectors, axis=1)
+        norms[norms == 0] = 1.0
+        self._vectors = vectors / norms[:, np.newaxis]
+        self._labels = list(labels)
+        if embedding_ids is not None and len(embedding_ids) != len(labels):
+            raise ValueError("embedding_ids length must match labels length")
+        self._embedding_ids = list(embedding_ids) if embedding_ids is not None else list(labels)
+        self._label_is_user = {label: bool(value) for label, value in (label_is_user or {}).items()}
+
+    @property
+    def dimension(self) -> int:
+        """Return the dimensionality of the index."""
+
+        return int(self._vectors.shape[1]) if self._vectors.size else 0
+
+    def __len__(self) -> int:  # pragma: no cover - trivial
+        return int(self._vectors.shape[0])
+
+    def is_user(self, label: str) -> bool:
+        """Return whether ``label`` represents a known user."""
+
+        return bool(self._label_is_user.get(label, False))
+
+    def search(self, embedding: ArrayLike, *, limit: int = 1) -> List[FaceMatch]:
+        """Return the most similar labels for ``embedding``."""
+
+        if self._vectors.size == 0:
+            return []
+        vector = np.asarray(embedding, dtype=np.float32)
+        if vector.ndim != 1:
+            raise ValueError("embedding must be 1D")
+        if vector.shape[0] != self._vectors.shape[1]:
+            raise ValueError("embedding dimension mismatch")
+        norm = float(np.linalg.norm(vector))
+        if not math.isfinite(norm) or norm == 0.0:
+            return []
+        normalised = vector / norm
+        similarities = self._vectors @ normalised
+        order = np.argsort(similarities)[::-1]
+        results: List[FaceMatch] = []
+        for rank in order[: max(1, limit)]:
+            similarity = float(similarities[rank])
+            results.append(
+                FaceMatch(
+                    label=self._labels[int(rank)],
+                    similarity=similarity,
+                    embedding_id=self._embedding_ids[int(rank)],
+                    index=int(rank),
+                )
+            )
+        return results
+
+
+@dataclass
+class FaceIdentityConfig:
+    """Configuration values controlling face identity resolution."""
+
+    user_similarity_threshold: float = 0.72
+    guest_similarity_threshold: float = 0.62
+    unknown_label: str = "unknown"
+    fallback_to_heuristic_for_unknown: bool = False
+
+
+@dataclass
+class FaceIdentityDecision:
+    """Outcome returned by :class:`FaceIdentityResolver`."""
+
+    result: "IdentityResult"
+    embedding_id: Optional[str] = None
+    similarity: Optional[float] = None
+    snapshot_age: Optional[float] = None
+    used_fallback: bool = False
+
+
+class FaceIdentityResolver:
+    """Combine face embeddings with heuristics to classify people."""
+
+    def __init__(
+        self,
+        classifier: "IdentityClassifier",
+        index: Optional[FaceEmbeddingIndex],
+        cache: FaceSnapshotCache,
+        config: FaceIdentityConfig,
+        *,
+        snapshot_fetcher: Callable[[int], Optional[FaceSnapshot]] | None = None,
+    ) -> None:
+        self.classifier = classifier
+        self.index = index
+        self.cache = cache
+        self.config = config
+        self._snapshot_fetcher = snapshot_fetcher
+
+    def update_snapshot(self, snapshot: FaceSnapshot) -> None:
+        """Update the cached snapshot for the corresponding track."""
+
+        self.cache.update(snapshot)
+
+    def resolve(
+        self,
+        observation: "IdentityObservation",
+        track_id: int,
+    ) -> FaceIdentityDecision:
+        """Return an identity decision for ``track_id``."""
+
+        snapshot: Optional[FaceSnapshot]
+        age: Optional[float]
+        snapshot, age = self.cache.get(track_id)
+        if snapshot is None and track_id >= 0 and self._snapshot_fetcher is not None:
+            fetched = self._snapshot_fetcher(track_id)
+            if fetched is not None:
+                self.cache.update(fetched)
+                snapshot, age = self.cache.get(track_id)
+
+        if snapshot is None or self.index is None or len(self.index) == 0:
+            fallback = self.classifier.classify(observation)
+            reason = "No face embedding available"
+            if track_id >= 0:
+                reason += f" for track {track_id}"
+            if fallback.reason:
+                reason = f"{reason}; {fallback.reason}"
+            result = IdentityResult(
+                label=fallback.label,
+                is_user=fallback.is_user,
+                confidence=fallback.confidence,
+                reason=reason,
+            )
+            return FaceIdentityDecision(
+                result=result,
+                used_fallback=True,
+            )
+
+        matches = self.index.search(snapshot.embedding, limit=1)
+        if not matches:
+            return self._unknown_result(observation, track_id, age, similarity=None)
+
+        match = matches[0]
+        is_user = self.index.is_user(match.label)
+        threshold = (
+            self.config.user_similarity_threshold if is_user else self.config.guest_similarity_threshold
+        )
+        if match.similarity >= threshold:
+            reason = (
+                f"cosine similarity {match.similarity:.3f} >= "
+                f"threshold {threshold:.3f} for label '{match.label}'"
+            )
+            confidence = float(np.clip(match.similarity, 0.0, 1.0))
+            result = IdentityResult(
+                label=match.label,
+                is_user=is_user,
+                confidence=confidence,
+                reason=reason,
+            )
+            return FaceIdentityDecision(
+                result=result,
+                embedding_id=match.embedding_id,
+                similarity=match.similarity,
+                snapshot_age=age,
+                used_fallback=False,
+            )
+
+        if self.config.fallback_to_heuristic_for_unknown:
+            fallback = self.classifier.classify(observation)
+            reason = (
+                f"Face similarity {match.similarity:.3f} below threshold "
+                f"{threshold:.3f}; {fallback.reason}"
+            )
+            result = IdentityResult(
+                label=fallback.label,
+                is_user=fallback.is_user,
+                confidence=fallback.confidence,
+                reason=reason,
+            )
+            return FaceIdentityDecision(
+                result=result,
+                embedding_id=match.embedding_id,
+                similarity=match.similarity,
+                snapshot_age=age,
+                used_fallback=True,
+            )
+
+        return self._unknown_result(observation, track_id, age, match.similarity, match.embedding_id)
+
+    def _unknown_result(
+        self,
+        observation: "IdentityObservation",
+        track_id: int,
+        age: Optional[float],
+        similarity: Optional[float],
+        embedding_id: Optional[str] = None,
+    ) -> FaceIdentityDecision:
+        similarity_value = float(similarity) if similarity is not None else 0.0
+        similarity_value = float(np.clip(similarity_value, 0.0, 1.0))
+        reason = "Face embedding below similarity threshold"
+        if track_id >= 0:
+            reason += f" for track {track_id}"
+        if similarity is not None:
+            reason += f" (score {similarity:.3f})"
+        result = IdentityResult(
+            label=self.config.unknown_label,
+            is_user=False,
+            confidence=similarity_value,
+            reason=reason,
+        )
+        return FaceIdentityDecision(
+            result=result,
+            embedding_id=embedding_id,
+            similarity=similarity,
+            snapshot_age=age,
+            used_fallback=False,
+        )
+
+
+def load_face_index(
+    path: Optional[Path],
+    *,
+    metadata_path: Optional[Path] = None,
+) -> Optional[FaceEmbeddingIndex]:
+    """Load a :class:`FaceEmbeddingIndex` from JSON/YAML configuration files."""
+
+    if path is None:
+        return None
+    if not str(path):
+        return None
+    index_path = Path(path)
+    if not index_path.exists():
+        raise FileNotFoundError(f"Face index path '{index_path}' does not exist")
+    data = load_file(index_path)
+    records: Iterable[Mapping[str, object]]
+    if "records" in data:
+        records = list(data["records"] or [])
+    else:
+        labels = data.get("labels") or []
+        embeddings = data.get("embeddings") or []
+        if len(labels) != len(embeddings):
+            raise ValueError("labels and embeddings length mismatch in face index config")
+        records = [
+            {"label": label, "embedding": emb}
+            for label, emb in zip(labels, embeddings)
+        ]
+        if not records:
+            return None
+    embeddings_list: List[np.ndarray] = []
+    labels: List[str] = []
+    embedding_ids: List[str] = []
+    is_user_map: Dict[str, bool] = {}
+    for record in records:
+        label = str(record.get("label"))
+        embedding = np.asarray(record.get("embedding"), dtype=np.float32)
+        if embedding.ndim != 1:
+            raise ValueError("face embedding entries must be 1D vectors")
+        embeddings_list.append(embedding)
+        labels.append(label)
+        embedding_ids.append(str(record.get("embedding_id", label)))
+        if "is_user" in record:
+            is_user_map[label] = bool(record.get("is_user"))
+
+    if not embeddings_list:
+        return None
+
+    if metadata_path is not None and str(metadata_path):
+        meta_file = Path(metadata_path)
+        if meta_file.exists():
+            metadata = load_file(meta_file)
+            if isinstance(metadata, Mapping):
+                for label, value in metadata.get("label_metadata", {}).items():
+                    if isinstance(value, Mapping) and "is_user" in value:
+                        is_user_map[str(label)] = bool(value["is_user"])
+
+    return FaceEmbeddingIndex(
+        embeddings=np.vstack(embeddings_list),
+        labels=labels,
+        embedding_ids=embedding_ids,
+        label_is_user=is_user_map,
+    )
+
+
+from .identity import IdentityClassifier, IdentityObservation, IdentityResult
+
+
+__all__ = [
+    "FaceEmbeddingIndex",
+    "FaceIdentityConfig",
+    "FaceIdentityDecision",
+    "FaceIdentityResolver",
+    "FaceSnapshot",
+    "FaceSnapshotCache",
+    "FaceMatch",
+    "load_face_index",
+]
+


### PR DESCRIPTION
## Summary
- add face identity utilities for snapshot caching, embedding lookup, and FAISS-style thresholds
- refactor identity_node to load face configs, resolve requests via face embeddings, and return enhanced diagnostics
- allow detector_node to opt-in to embedding diagnostics and extend identity tests for cache/heuristic coverage

## Testing
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest ros2_ws/src/altinet/altinet/tests

------
https://chatgpt.com/codex/tasks/task_e_68d34ecd5b08832fa752c3f8b66abe64