### PR TITLE
Add motion-aware detection gating and room context manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 .venv/
+frontend/node_modules/

--- a/ros2_ws/src/altinet/altinet/nodes/ros2_django_bridge_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/ros2_django_bridge_node.py
@@ -41,7 +41,7 @@ from ..utils.types import (
     BoundingBox,
     Event as EventModel,
     FaceEnrolmentConfirmation as FaceEnrolmentModel,
-    FaceSnapshot as FaceSnapshotModel,
+    FaceSnapshotRecord as FaceSnapshotModel,
     RoomPresence as RoomPresenceModel,
     Track,
 )

--- a/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/tracker_node.py
@@ -61,6 +61,11 @@ class TrackerPipeline:
             predicted.append(replace(track, bbox=bbox, timestamp=now))
         return predicted
 
+    def assign_identity(self, track_id: int, identity_id: str, confidence: float) -> bool:
+        """Associate a known identity with a track."""
+
+        return self.tracker.assign_identity(track_id, identity_id, confidence)
+
 
 class TrackerNode(Node):  # pragma: no cover - requires ROS runtime
     """ROS 2 node bridging detection and tracking stages."""

--- a/ros2_ws/src/altinet/altinet/tests/test_bridge.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_bridge.py
@@ -9,7 +9,7 @@ from altinet.utils.types import (
     BoundingBox,
     Event,
     FaceEnrolmentConfirmation,
-    FaceSnapshot,
+    FaceSnapshotRecord,
     RoomPresence,
     Track,
 )
@@ -92,7 +92,7 @@ def test_bridge_handles_face_messages():
     )
     transport = DummyTransport()
     bridge = DjangoBridge(config, transport=transport)
-    snapshot = FaceSnapshot(
+    snapshot = FaceSnapshotRecord(
         identity_id="alice",
         embedding_id="emb1",
         track_id=7,

--- a/ros2_ws/src/altinet/altinet/tests/test_context_manager.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_context_manager.py
@@ -1,0 +1,52 @@
+"""Tests for the room context manager."""
+
+from datetime import datetime, timedelta
+
+from altinet.utils.context import RoomContextManager
+from altinet.utils.types import BoundingBox, Track
+
+
+def make_track(track_id: int, timestamp: datetime) -> Track:
+    return Track(
+        track_id=track_id,
+        bbox=BoundingBox(10.0, 10.0, 50.0, 80.0),
+        confidence=0.9,
+        room_id="living_room",
+        timestamp=timestamp,
+        image_size=(720, 1280),
+    )
+
+
+def test_context_manager_tracks_people_and_environment():
+    manager = RoomContextManager()
+    t0 = datetime.utcnow()
+    track = make_track(1, t0)
+
+    manager.update_presence("living_room", [track], t0)
+    context = manager.get_room_context("living_room")
+    assert set(context.people.keys()) == {1}
+    assert context.people[1].last_seen == t0
+
+    manager.assign_identity(1, "alice", 0.87, t0 + timedelta(seconds=1))
+    context = manager.get_room_context("living_room")
+    person = context.people[1]
+    assert person.identity_id == "alice"
+    assert person.identity_confidence == 0.87
+
+    manager.update_environment(
+        "living_room",
+        brightness=0.5,
+        light_states={"ceiling": True},
+        temperature=21.5,
+        timestamp=t0 + timedelta(seconds=2),
+    )
+    manager.note_motion("living_room", t0 + timedelta(seconds=2))
+    context = manager.get_room_context("living_room")
+    assert context.brightness == 0.5
+    assert context.light_states["ceiling"] is True
+    assert context.temperature == 21.5
+    assert context.last_motion == t0 + timedelta(seconds=2)
+
+    manager.update_presence("living_room", [], t0 + timedelta(seconds=3))
+    context = manager.get_room_context("living_room")
+    assert not context.people

--- a/ros2_ws/src/altinet/altinet/tests/test_event_manager.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_event_manager.py
@@ -43,6 +43,9 @@ def test_event_manager_generates_entry_exit_and_position_change():
     assert centroid[0] == pytest.approx((10.0 + 25.0) / 1280.0)
     assert centroid[1] == pytest.approx((20.0 + 40.0) / 720.0)
     assert presence[0].count == 1
+    context = manager.context.get_room_context("living_room")
+    assert set(context.people.keys()) == {1}
+    assert context.people[1].identity_id is None
 
     events, _ = manager.update(
         [make_track(1, 40.0, 20.0, t0 + timedelta(milliseconds=33))]
@@ -60,3 +63,4 @@ def test_event_manager_generates_entry_exit_and_position_change():
     events, presence = manager.update([])
     assert any(event.type == "EXIT" for event in events)
     assert any(p.room_id == "living_room" and p.count == 0 for p in presence)
+    assert not manager.context.get_room_context("living_room").people

--- a/ros2_ws/src/altinet/altinet/tests/test_scene_monitor.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_scene_monitor.py
@@ -1,0 +1,77 @@
+"""Tests for the scene change detector."""
+
+import numpy as np
+
+from altinet.utils.scene_monitor import SceneActivityConfig, SceneChangeDetector
+
+
+class _Clock:
+    def __init__(self):
+        self.value = 0.0
+
+    def __call__(self):
+        current = self.value
+        self.value += 0.1
+        return current
+
+
+def test_scene_detector_triggers_on_motion():
+    config = SceneActivityConfig(
+        motion_threshold=0.01,
+        checks_after_motion=2,
+        checks_while_tracking=0,
+        min_trigger_interval_s=0.0,
+    )
+    detector = SceneChangeDetector(config, clock=_Clock())
+    frame_a = np.zeros((8, 8, 3), dtype=np.uint8)
+    frame_b = np.full((8, 8, 3), 255, dtype=np.uint8)
+
+    decision1 = detector.observe("living_room", frame_a)
+    assert not decision1.should_detect
+
+    decision2 = detector.observe("living_room", frame_b)
+    assert decision2.should_detect
+    assert decision2.motion_detected
+
+    decision3 = detector.observe("living_room", frame_b)
+    assert decision3.should_detect  # second check due to motion
+
+    decision4 = detector.observe("living_room", frame_a)
+    assert decision4.should_detect
+    assert decision4.motion_detected  # returning to baseline counts as change
+
+    decision5 = detector.observe("living_room", frame_a)
+    assert decision5.should_detect
+    assert not decision5.motion_detected
+
+    decision6 = detector.observe("living_room", frame_a)
+    assert not decision6.should_detect
+
+
+def test_scene_detector_extends_after_detection():
+    config = SceneActivityConfig(
+        motion_threshold=0.01,
+        checks_after_motion=1,
+        checks_while_tracking=3,
+        min_trigger_interval_s=0.0,
+    )
+    detector = SceneChangeDetector(config, clock=_Clock())
+    frame_static = np.zeros((4, 4), dtype=np.uint8)
+    frame_motion = np.full((4, 4), 255, dtype=np.uint8)
+
+    detector.observe("hall", frame_static)
+    detector.observe("hall", frame_motion)
+    detector.notify_detection_result("hall", True)
+
+    decisions = [detector.observe("hall", frame_static) for _ in range(3)]
+    assert all(dec.should_detect for dec in decisions)
+
+    final_decision = detector.observe("hall", frame_static)
+    assert final_decision.should_detect
+    assert not final_decision.motion_detected
+
+    tail_decision = detector.observe("hall", frame_static)
+    assert not tail_decision.should_detect
+
+    detector.notify_detection_result("hall", False)
+    assert not detector.observe("hall", frame_static).should_detect

--- a/ros2_ws/src/altinet/altinet/utils/context.py
+++ b/ros2_ws/src/altinet/altinet/utils/context.py
@@ -1,0 +1,149 @@
+"""Utilities for tracking live contextual information about rooms."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Iterable, Optional
+
+from .types import Track
+
+
+@dataclass
+class PersonContext:
+    """Represents a tracked person inside a room."""
+
+    track_id: int
+    last_seen: datetime
+    identity_id: Optional[str] = None
+    identity_confidence: float = 0.0
+
+
+@dataclass
+class RoomContext:
+    """Aggregated room state maintained by :class:`RoomContextManager`."""
+
+    room_id: str
+    people: Dict[int, PersonContext] = field(default_factory=dict)
+    last_updated: Optional[datetime] = None
+    last_motion: Optional[datetime] = None
+    brightness: Optional[float] = None
+    light_states: Dict[str, bool] = field(default_factory=dict)
+    temperature: Optional[float] = None
+    metadata: Dict[str, object] = field(default_factory=dict)
+
+
+class RoomContextManager:
+    """Maintain live context about rooms and their occupants."""
+
+    def __init__(self) -> None:
+        self._rooms: Dict[str, RoomContext] = {}
+        self._track_index: Dict[int, str] = {}
+
+    # ------------------------------------------------------------------
+    # Context updates
+    # ------------------------------------------------------------------
+    def update_presence(
+        self,
+        room_id: str,
+        tracks: Iterable[Track],
+        timestamp: datetime,
+    ) -> None:
+        """Synchronise people present in ``room_id`` with ``tracks``."""
+
+        context = self._rooms.setdefault(room_id, RoomContext(room_id=room_id))
+        context.last_updated = timestamp
+        active_ids = {track.track_id for track in tracks}
+        for track_id in list(context.people.keys()):
+            if track_id not in active_ids:
+                context.people.pop(track_id, None)
+                self._track_index.pop(track_id, None)
+        for track in tracks:
+            person = context.people.get(track.track_id)
+            if person is None:
+                person = PersonContext(track_id=track.track_id, last_seen=timestamp)
+                context.people[track.track_id] = person
+            else:
+                person.last_seen = timestamp
+            if getattr(track, "identity_id", None):
+                person.identity_id = track.identity_id
+                person.identity_confidence = getattr(
+                    track, "identity_confidence", person.identity_confidence
+                )
+            elif getattr(track, "identity_confidence", 0.0) > person.identity_confidence:
+                person.identity_confidence = track.identity_confidence
+            self._track_index[track.track_id] = room_id
+
+    def assign_identity(
+        self,
+        track_id: int,
+        identity_id: str,
+        confidence: float,
+        timestamp: Optional[datetime] = None,
+    ) -> bool:
+        """Assign a known identity to ``track_id`` if the track is active."""
+
+        room_id = self._track_index.get(track_id)
+        if room_id is None:
+            return False
+        context = self._rooms.setdefault(room_id, RoomContext(room_id=room_id))
+        person = context.people.get(track_id)
+        if person is None:
+            if timestamp is None:
+                timestamp = datetime.utcnow()
+            person = PersonContext(track_id=track_id, last_seen=timestamp)
+            context.people[track_id] = person
+        if timestamp is None:
+            timestamp = datetime.utcnow()
+        person.identity_id = identity_id
+        person.identity_confidence = confidence
+        person.last_seen = timestamp
+        context.last_updated = timestamp
+        return True
+
+    def update_environment(
+        self,
+        room_id: str,
+        *,
+        timestamp: Optional[datetime] = None,
+        brightness: Optional[float] = None,
+        light_states: Optional[Dict[str, bool]] = None,
+        temperature: Optional[float] = None,
+    ) -> None:
+        """Record environmental metrics for ``room_id``."""
+
+        context = self._rooms.setdefault(room_id, RoomContext(room_id=room_id))
+        if timestamp is None:
+            timestamp = datetime.utcnow()
+        context.last_updated = timestamp
+        if brightness is not None:
+            context.brightness = float(brightness)
+        if light_states is not None:
+            context.light_states.update(light_states)
+        if temperature is not None:
+            context.temperature = float(temperature)
+
+    def note_motion(self, room_id: str, timestamp: Optional[datetime] = None) -> None:
+        """Record the latest timestamp when motion was observed."""
+
+        context = self._rooms.setdefault(room_id, RoomContext(room_id=room_id))
+        context.last_motion = timestamp or datetime.utcnow()
+
+    # ------------------------------------------------------------------
+    # Read-only access
+    # ------------------------------------------------------------------
+    def get_room_context(self, room_id: str) -> RoomContext:
+        """Return a defensive copy of the context for ``room_id``."""
+
+        context = self._rooms.setdefault(room_id, RoomContext(room_id=room_id))
+        return copy.deepcopy(context)
+
+    def snapshot(self) -> Dict[str, RoomContext]:
+        """Return a snapshot of all known rooms."""
+
+        return {room_id: self.get_room_context(room_id) for room_id in self._rooms}
+
+
+__all__ = ["PersonContext", "RoomContext", "RoomContextManager"]
+

--- a/ros2_ws/src/altinet/altinet/utils/scene_monitor.py
+++ b/ros2_ws/src/altinet/altinet/utils/scene_monitor.py
@@ -1,0 +1,126 @@
+"""Utilities for monitoring camera scenes and detecting motion events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional
+
+import numpy as np
+
+
+@dataclass
+class SceneActivityConfig:
+    """Configuration parameters controlling motion-triggered detection."""
+
+    motion_threshold: float = 0.02
+    min_trigger_interval_s: float = 0.5
+    checks_after_motion: int = 3
+    checks_while_tracking: int = 6
+
+
+@dataclass
+class SceneDecision:
+    """Result of evaluating a frame for motion."""
+
+    should_detect: bool
+    motion_detected: bool
+    motion_score: float
+
+
+@dataclass
+class _SceneState:
+    """Internal per-room state for :class:`SceneChangeDetector`."""
+
+    previous_frame: Optional[np.ndarray] = None
+    pending_checks: int = 0
+    tracking_checks: int = 0
+    last_motion_time: float = 0.0
+    motion_score: float = 0.0
+    tracking_active: bool = False
+
+
+def _to_float_gray(frame: np.ndarray) -> np.ndarray:
+    """Convert ``frame`` to a contiguous float32 grayscale array."""
+
+    if not isinstance(frame, np.ndarray):
+        raise TypeError("frame must be a numpy.ndarray")
+    gray = frame
+    if gray.ndim == 3:
+        gray = gray.mean(axis=2)
+    if not np.issubdtype(gray.dtype, np.floating):
+        gray = gray.astype(np.float32)
+    else:
+        gray = np.asarray(gray, dtype=np.float32)
+    if not gray.flags.c_contiguous:
+        gray = np.ascontiguousarray(gray)
+    return gray
+
+
+class SceneChangeDetector:
+    """Detect scene changes and control when person detection should run."""
+
+    def __init__(
+        self,
+        config: SceneActivityConfig | None = None,
+        *,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self.config = config or SceneActivityConfig()
+        self._clock: Callable[[], float] = clock or __import__("time").monotonic
+        self._states: Dict[str, _SceneState] = {}
+
+    def observe(self, room_id: str, frame: np.ndarray) -> SceneDecision:
+        """Inspect ``frame`` and decide whether to trigger detection."""
+
+        state = self._states.setdefault(room_id, _SceneState())
+        gray = _to_float_gray(frame)
+        motion_detected = False
+        score = 0.0
+        if state.previous_frame is not None and state.previous_frame.shape == gray.shape:
+            diff = np.abs(gray - state.previous_frame)
+            if diff.size:
+                score = float(np.mean(diff) / 255.0)
+                motion_detected = score >= self.config.motion_threshold
+        state.previous_frame = gray
+        now = self._clock()
+        should_detect = False
+        if motion_detected:
+            if now - state.last_motion_time >= self.config.min_trigger_interval_s:
+                state.pending_checks = max(
+                    state.pending_checks, self.config.checks_after_motion
+                )
+                state.last_motion_time = now
+            else:
+                state.pending_checks = max(1, state.pending_checks)
+            state.motion_score = score
+        if state.pending_checks > 0:
+            should_detect = True
+            state.pending_checks -= 1
+        elif state.tracking_active and state.tracking_checks > 0:
+            should_detect = True
+            state.tracking_checks -= 1
+            if state.tracking_checks == 0:
+                state.tracking_active = False
+        else:
+            state.motion_score = score
+        return SceneDecision(
+            should_detect=should_detect,
+            motion_detected=motion_detected,
+            motion_score=score,
+        )
+
+    def notify_detection_result(self, room_id: str, person_found: bool) -> None:
+        """Update tracking state based on the latest detection outcome."""
+
+        state = self._states.setdefault(room_id, _SceneState())
+        if person_found:
+            if not state.tracking_active:
+                state.tracking_active = True
+                state.tracking_checks = max(0, self.config.checks_while_tracking)
+        else:
+            state.tracking_active = False
+            state.tracking_checks = 0
+
+
+__all__ = ["SceneActivityConfig", "SceneChangeDetector", "SceneDecision"]
+

--- a/ros2_ws/src/altinet/altinet/utils/tracking.py
+++ b/ros2_ws/src/altinet/altinet/utils/tracking.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from typing import Dict, Iterable, List, Tuple
 
@@ -84,6 +84,8 @@ class ByteTrack:
                 velocity=velocity,
                 hits=track.hits + 1,
                 age=0,
+                identity_id=track.identity_id,
+                identity_confidence=track.identity_confidence,
             )
 
         for track_id in unmatched_tracks:
@@ -100,6 +102,8 @@ class ByteTrack:
                 velocity=track.velocity,
                 hits=track.hits,
                 age=track.age + 1,
+                identity_id=track.identity_id,
+                identity_confidence=track.identity_confidence,
             )
 
         for det_idx in unmatched_detections:
@@ -116,10 +120,25 @@ class ByteTrack:
                 velocity=(0.0, 0.0),
                 hits=1,
                 age=0,
+                identity_id=None,
+                identity_confidence=0.0,
             )
 
         self.tracks = updated_tracks
         return list(self.tracks.values())
+
+    def assign_identity(self, track_id: int, identity_id: str, confidence: float) -> bool:
+        """Assign ``identity_id`` to an active track."""
+
+        track = self.tracks.get(track_id)
+        if track is None:
+            return False
+        self.tracks[track_id] = replace(
+            track,
+            identity_id=identity_id,
+            identity_confidence=confidence,
+        )
+        return True
 
 
 def _estimate_velocity(track: Track, detection: Detection) -> Tuple[float, float]:

--- a/ros2_ws/src/altinet/altinet/utils/types.py
+++ b/ros2_ws/src/altinet/altinet/utils/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Dict, List, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -83,6 +83,8 @@ class Track:
     velocity: Tuple[float, float] = (0.0, 0.0)
     hits: int = 1
     age: int = 0
+    identity_id: Optional[str] = None
+    identity_confidence: float = 0.0
 
     def centroid(self) -> Tuple[float, float]:
         """Return the centroid of the tracked bounding box."""
@@ -200,7 +202,7 @@ class LightCommand:
 
 
 @dataclass
-class FaceSnapshot:
+class FaceSnapshotRecord:
     """Metadata published when a new face embedding snapshot is captured."""
 
     identity_id: str
@@ -234,6 +236,6 @@ __all__ = [
     "RoomPresence",
     "Event",
     "LightCommand",
-    "FaceSnapshot",
+    "FaceSnapshotRecord",
     "FaceEnrolmentConfirmation",
 ]


### PR DESCRIPTION
## Summary
- add a scene activity monitor to gate person detection and reduce work when frames are unchanged
- introduce a room context manager and hook it into the event manager to track live presence, motion and brightness metadata
- propagate identity information through the tracking pipeline and update bridge code to use the new face snapshot record model

## Testing
- PYTHONPATH=/workspace/altinet:/workspace/altinet/ros2_ws/src pytest ros2_ws/src/altinet/altinet/tests

------
https://chatgpt.com/codex/tasks/task_e_68d37094d4b4832f947c753bbe124d4c