### PR TITLE
Add authentication flows and live dashboard UI

### DIFF
--- a/backend/spaces/auth_views.py
+++ b/backend/spaces/auth_views.py
@@ -1,0 +1,135 @@
+"""API views for basic session authentication flows."""
+
+from __future__ import annotations
+
+from django.contrib.auth import authenticate, get_user_model, login, logout
+from django.db import IntegrityError, transaction
+from django.utils.translation import gettext_lazy as _
+from rest_framework import status
+from rest_framework.permissions import AllowAny, IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .authentication import CsrfExemptSessionAuthentication
+
+User = get_user_model()
+
+
+def _serialise_user(user: User) -> dict[str, str]:
+    return {
+        "id": str(user.pk),
+        "username": user.get_username(),
+        "first_name": user.first_name,
+        "last_name": user.last_name,
+        "email": user.email,
+    }
+
+
+class AuthStatusView(APIView):
+    """Return authentication status and whether any users exist."""
+
+    permission_classes = [AllowAny]
+    authentication_classes = [CsrfExemptSessionAuthentication]
+
+    def get(self, request: Request) -> Response:
+        has_users = User.objects.exists()
+        payload: dict[str, object] = {
+            "has_users": has_users,
+            "is_authenticated": request.user.is_authenticated,
+        }
+        if request.user.is_authenticated:
+            payload["user"] = _serialise_user(request.user)
+        else:
+            payload["user"] = None
+        return Response(payload)
+
+
+class RegisterView(APIView):
+    """Create the initial user when none exist."""
+
+    permission_classes = [AllowAny]
+    authentication_classes: list[type] = []
+
+    def post(self, request: Request) -> Response:
+        if User.objects.exists():
+            return Response(
+                {"detail": _("Registration is disabled once an operator exists.")},
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        username = (request.data.get("username") or "").strip()
+        password = request.data.get("password") or ""
+        email = (request.data.get("email") or "").strip()
+        first_name = (request.data.get("first_name") or "").strip()
+        last_name = (request.data.get("last_name") or "").strip()
+
+        if not username or not password:
+            return Response(
+                {"detail": _("Username and password are required.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            with transaction.atomic():
+                user = User.objects.create_user(
+                    username=username,
+                    password=password,
+                    email=email,
+                    first_name=first_name,
+                    last_name=last_name,
+                )
+        except IntegrityError:
+            return Response(
+                {"detail": _("Unable to create user with the provided credentials.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        login(request, user)
+        return Response(_serialise_user(user), status=status.HTTP_201_CREATED)
+
+
+class LoginView(APIView):
+    """Authenticate an existing user and begin a session."""
+
+    permission_classes = [AllowAny]
+    authentication_classes = [CsrfExemptSessionAuthentication]
+
+    def post(self, request: Request) -> Response:
+        username = (request.data.get("username") or "").strip()
+        password = request.data.get("password") or ""
+        if not username or not password:
+            return Response(
+                {"detail": _("Username and password are required.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user = authenticate(request, username=username, password=password)
+        if user is None:
+            return Response(
+                {"detail": _("Invalid username or password.")},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        login(request, user)
+        return Response(_serialise_user(user))
+
+
+class LogoutView(APIView):
+    """Terminate the active session."""
+
+    permission_classes = [IsAuthenticated]
+    authentication_classes = [CsrfExemptSessionAuthentication]
+
+    def post(self, request: Request) -> Response:
+        logout(request)
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+__all__ = [
+    "AuthStatusView",
+    "RegisterView",
+    "LoginView",
+    "LogoutView",
+]
+

--- a/backend/spaces/authentication.py
+++ b/backend/spaces/authentication.py
@@ -1,0 +1,22 @@
+"""Authentication utilities for API views."""
+
+from __future__ import annotations
+
+from rest_framework.authentication import SessionAuthentication
+
+
+class CsrfExemptSessionAuthentication(SessionAuthentication):
+    """Session authentication that skips CSRF enforcement.
+
+    The frontend is a single-page application that communicates with the
+    backend using the Django session cookie. Generating CSRF tokens in that
+    context adds friction, so we explicitly relax the CSRF requirement for the
+    authentication endpoints that operate over HTTPS.
+    """
+
+    def enforce_csrf(self, request):  # type: ignore[override]
+        return None
+
+
+__all__ = ["CsrfExemptSessionAuthentication"]
+

--- a/backend/spaces/consumers.py
+++ b/backend/spaces/consumers.py
@@ -33,3 +33,22 @@ class CalibrationProgressConsumer(AsyncJsonWebsocketConsumer):
 
     async def calibration_progress_event(self, event):
         await self.send_json(event["payload"])
+
+
+class PersonTrackConsumer(AsyncJsonWebsocketConsumer):
+    group_names = ["person_tracks"]
+
+    async def connect(self) -> None:
+        for group in self.group_names:
+            await self.channel_layer.group_add(group, self.channel_name)
+        await self.accept()
+
+    async def disconnect(self, close_code: int) -> None:  # pragma: no cover
+        for group in self.group_names:
+            await self.channel_layer.group_discard(group, self.channel_name)
+
+    async def person_track_event(self, event):
+        await self.send_json(event["payload"])
+
+    async def room_presence_event(self, event):
+        await self.send_json(event["payload"])

--- a/backend/spaces/event_views.py
+++ b/backend/spaces/event_views.py
@@ -1,0 +1,77 @@
+"""Views for ingesting real-time events from ROS bridge."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, Sequence
+
+from rest_framework import status
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .events import broadcast_person_track, broadcast_room_presence
+
+
+class EventIngestView(APIView):
+    """Accept events from the ROS→Django bridge and fan them out."""
+
+    permission_classes = [AllowAny]
+    authentication_classes: Sequence[type] = []
+
+    def post(self, request: Request) -> Response:
+        event_type = (request.data.get("type") or "").upper()
+        if event_type == "TRACK":
+            return self._handle_track(request.data)
+        if event_type == "PRESENCE":
+            return self._handle_presence(request.data)
+        # Other event types are accepted but ignored for now to keep the
+        # pipeline extensible.
+        return Response({"status": "ignored"}, status=status.HTTP_202_ACCEPTED)
+
+    def _handle_track(self, data: Dict[str, Any]) -> Response:
+        room_id = data.get("room_id")
+        track_id = data.get("track_id")
+        centroid = data.get("centroid")
+        if room_id is None or track_id is None or not isinstance(centroid, Iterable):
+            return Response(
+                {"detail": "room_id, track_id and centroid are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        try:
+            coords = [float(value) for value in centroid][:2]
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": "centroid must contain numeric values."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        payload = {
+            "event": "TRACK",
+            "room_id": str(room_id),
+            "track_id": str(track_id),
+            "centroid": coords,
+            "timestamp": data.get("timestamp"),
+        }
+        broadcast_person_track(payload)
+        return Response({"status": "ok"}, status=status.HTTP_202_ACCEPTED)
+
+    def _handle_presence(self, data: Dict[str, Any]) -> Response:
+        room_id = data.get("room_id")
+        track_ids = data.get("track_ids")
+        if room_id is None or not isinstance(track_ids, list):
+            return Response(
+                {"detail": "room_id and track_ids are required."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        payload = {
+            "event": "PRESENCE",
+            "room_id": str(room_id),
+            "track_ids": [str(track) for track in track_ids],
+            "timestamp": data.get("timestamp"),
+        }
+        broadcast_room_presence(payload)
+        return Response({"status": "ok"}, status=status.HTTP_202_ACCEPTED)
+
+
+__all__ = ["EventIngestView"]
+

--- a/backend/spaces/events.py
+++ b/backend/spaces/events.py
@@ -31,6 +31,28 @@ def broadcast_calibration_progress(camera_id: str, payload: Dict[str, Any]) -> N
     )
 
 
+def broadcast_person_track(payload: Dict[str, Any]) -> None:
+    channel_layer = get_channel_layer()
+    if channel_layer is None:  # pragma: no cover
+        return
+    _send_group_message(
+        channel_layer,
+        "person_tracks",
+        {"type": "person_track_event", "payload": payload},
+    )
+
+
+def broadcast_room_presence(payload: Dict[str, Any]) -> None:
+    channel_layer = get_channel_layer()
+    if channel_layer is None:  # pragma: no cover
+        return
+    _send_group_message(
+        channel_layer,
+        "person_tracks",
+        {"type": "room_presence_event", "payload": payload},
+    )
+
+
 def _send_group_message(channel_layer, group: str, message: Dict[str, Any]) -> None:
     try:
         loop = asyncio.get_running_loop()

--- a/backend/spaces/routing.py
+++ b/backend/spaces/routing.py
@@ -12,4 +12,5 @@ websocket_urlpatterns = [
         "ws/calibration/<uuid:camera_id>",
         consumers.CalibrationProgressConsumer.as_asgi(),
     ),
+    path("ws/tracks/", consumers.PersonTrackConsumer.as_asgi()),
 ]

--- a/backend/spaces/tests/test_auth_api.py
+++ b/backend/spaces/tests/test_auth_api.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+from django.contrib.auth import get_user_model
+
+
+@pytest.mark.django_db
+def test_auth_status_reports_user_count(api_client):
+    response = api_client.get("/api/auth/status/")
+    assert response.status_code == 200
+    assert response.data["has_users"] is False
+    assert response.data["is_authenticated"] is False
+
+    User = get_user_model()
+    User.objects.create_user(username="alice", password="secret123")
+
+    response = api_client.get("/api/auth/status/")
+    assert response.status_code == 200
+    assert response.data["has_users"] is True
+
+
+@pytest.mark.django_db
+def test_register_creates_first_user(api_client):
+    payload = {
+        "username": "operator",
+        "password": "supersecret",
+        "email": "ops@example.com",
+    }
+    response = api_client.post("/api/auth/register/", payload, format="json")
+    assert response.status_code == 201
+    assert response.data["username"] == "operator"
+
+    # Additional registration attempts should be rejected once a user exists.
+    response = api_client.post("/api/auth/register/", payload, format="json")
+    assert response.status_code == 403
+
+
+@pytest.mark.django_db
+def test_login_and_logout_flow(api_client):
+    User = get_user_model()
+    User.objects.create_user(username="alice", password="secret123")
+
+    login_response = api_client.post(
+        "/api/auth/login/",
+        {"username": "alice", "password": "secret123"},
+        format="json",
+    )
+    assert login_response.status_code == 200
+    assert login_response.data["username"] == "alice"
+
+    status_response = api_client.get("/api/auth/status/")
+    assert status_response.data["is_authenticated"] is True
+
+    logout_response = api_client.post("/api/auth/logout/")
+    assert logout_response.status_code == 204
+
+    status_response = api_client.get("/api/auth/status/")
+    assert status_response.data["is_authenticated"] is False
+

--- a/backend/spaces/tests/test_event_ingest.py
+++ b/backend/spaces/tests/test_event_ingest.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from unittest import mock
+
+import pytest
+
+
+@pytest.mark.django_db
+def test_track_events_are_broadcast(api_client):
+    payload = {
+        "type": "TRACK",
+        "room_id": "living_room",
+        "track_id": 1,
+        "centroid": [0.4, 0.6],
+        "timestamp": "2023-11-10T12:00:00Z",
+    }
+    with mock.patch("spaces.event_views.broadcast_person_track") as broadcast:
+        response = api_client.post("/api/events/", payload, format="json")
+    assert response.status_code == 202
+    broadcast.assert_called_once()
+    message = broadcast.call_args.args[0]
+    assert message["room_id"] == "living_room"
+    assert message["centroid"] == [0.4, 0.6]
+
+
+@pytest.mark.django_db
+def test_presence_events_are_broadcast(api_client):
+    payload = {
+        "type": "PRESENCE",
+        "room_id": "kitchen",
+        "track_ids": [1, 2, 3],
+        "timestamp": "2023-11-10T12:05:00Z",
+    }
+    with mock.patch("spaces.event_views.broadcast_room_presence") as broadcast:
+        response = api_client.post("/api/events/", payload, format="json")
+    assert response.status_code == 202
+    broadcast.assert_called_once()
+    message = broadcast.call_args.args[0]
+    assert message["track_ids"] == ["1", "2", "3"]
+

--- a/backend/spaces/urls.py
+++ b/backend/spaces/urls.py
@@ -12,6 +12,8 @@ from .views import (
     IdentityViewSet,
     RoomViewSet,
 )
+from .auth_views import AuthStatusView, LoginView, LogoutView, RegisterView
+from .event_views import EventIngestView
 
 router = DefaultRouter()
 router.register("rooms", RoomViewSet)
@@ -21,5 +23,10 @@ router.register("face-embeddings", FaceEmbeddingViewSet)
 router.register("face-snapshots", FaceSnapshotViewSet)
 
 urlpatterns = [
+    path("auth/status/", AuthStatusView.as_view(), name="auth-status"),
+    path("auth/register/", RegisterView.as_view(), name="auth-register"),
+    path("auth/login/", LoginView.as_view(), name="auth-login"),
+    path("auth/logout/", LogoutView.as_view(), name="auth-logout"),
+    path("events/", EventIngestView.as_view(), name="events-ingest"),
     path("", include(router.urls)),
 ]

--- a/frontend/src/components/auth/RequireAuth.tsx
+++ b/frontend/src/components/auth/RequireAuth.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { Navigate, useLocation } from "react-router-dom";
+
+import { useAuthStatus } from "../../lib/useAuth";
+
+const RequireAuth: React.FC<{ children: React.ReactElement }> = ({ children }) => {
+  const location = useLocation();
+  const { data, isLoading } = useAuthStatus();
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-200">
+        <span className="text-sm uppercase tracking-[0.4em] text-slate-500">Loading…</span>
+      </div>
+    );
+  }
+
+  if (!data?.is_authenticated) {
+    return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+  }
+
+  return children;
+};
+
+export default RequireAuth;
+

--- a/frontend/src/components/dashboard/LivePresenceFeed.tsx
+++ b/frontend/src/components/dashboard/LivePresenceFeed.tsx
@@ -1,0 +1,163 @@
+import React, { useEffect, useMemo, useState } from "react";
+
+import { Room } from "../../lib/api";
+import { createPersonTrackSocket, PersonTrackMessage, RoomPresenceMessage } from "../../lib/ws";
+
+type PersonState = {
+  trackId: string;
+  roomId: string;
+  centroid: [number, number];
+  lastSeen: number;
+};
+
+const STALE_TIMEOUT_MS = 12_000;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const normaliseCentroid = (value: unknown): [number, number] => {
+  if (Array.isArray(value) && value.length >= 2) {
+    const x = Number.isFinite(Number(value[0])) ? Number(value[0]) : 0.5;
+    const y = Number.isFinite(Number(value[1])) ? Number(value[1]) : 0.5;
+    return [x, y];
+  }
+  return [0.5, 0.5];
+};
+
+const LivePresenceFeed: React.FC<{ rooms: Room[] }> = ({ rooms }) => {
+  const [people, setPeople] = useState<Record<string, PersonState>>({});
+
+  useEffect(() => {
+    const socket = createPersonTrackSocket((message) => {
+      setPeople((current) => {
+        if ((message as PersonTrackMessage).event === "TRACK") {
+          const trackMessage = message as PersonTrackMessage;
+          const centroid = normaliseCentroid(trackMessage.centroid);
+          return {
+            ...current,
+            [trackMessage.track_id]: {
+              trackId: trackMessage.track_id,
+              roomId: trackMessage.room_id,
+              centroid,
+              lastSeen: Date.now()
+            }
+          };
+        }
+
+        const presenceMessage = message as RoomPresenceMessage;
+        const allowed = new Set(presenceMessage.track_ids);
+        const next: Record<string, PersonState> = {};
+        for (const [trackId, person] of Object.entries(current)) {
+          if (person.roomId !== presenceMessage.room_id) {
+            next[trackId] = person;
+          } else if (allowed.has(trackId)) {
+            next[trackId] = person;
+          }
+        }
+        return next;
+      });
+    });
+    return () => socket.close();
+  }, []);
+
+  useEffect(() => {
+    const interval = window.setInterval(() => {
+      setPeople((current) => {
+        const now = Date.now();
+        let hasChanges = false;
+        const next: Record<string, PersonState> = {};
+        for (const [trackId, person] of Object.entries(current)) {
+          if (now - person.lastSeen > STALE_TIMEOUT_MS) {
+            hasChanges = true;
+            continue;
+          }
+          next[trackId] = person;
+        }
+        return hasChanges ? next : current;
+      });
+    }, 4_000);
+    return () => window.clearInterval(interval);
+  }, []);
+
+  const roomsWithPeople = useMemo(() => {
+    const lookup: Record<string, PersonState[]> = {};
+    for (const person of Object.values(people)) {
+      lookup[person.roomId] = lookup[person.roomId] ?? [];
+      lookup[person.roomId].push(person);
+    }
+    return rooms.map((room) => ({
+      ...room,
+      occupants: lookup[room.id] ?? []
+    }));
+  }, [people, rooms]);
+
+  const totalPeople = Object.keys(people).length;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h2 className="text-2xl font-semibold text-slate-100">Live presence</h2>
+          <p className="text-sm text-slate-400">
+            Tracking nodes stream positions in real time. Each dot represents a detected person inside a calibrated room.
+          </p>
+        </div>
+        <div className="rounded-full border border-slate-700/60 bg-slate-900/80 px-5 py-2 text-sm font-semibold text-slate-200">
+          {totalPeople === 0 ? "No people detected" : `${totalPeople} ${totalPeople === 1 ? "person" : "people"} inside`}
+        </div>
+      </div>
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        {roomsWithPeople.map((room) => (
+          <div key={room.id} className="relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6">
+            <div className="flex items-baseline justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-slate-100">{room.name}</h3>
+                {room.level !== null && (
+                  <p className="text-xs uppercase tracking-[0.3em] text-slate-500">Level {room.level}</p>
+                )}
+              </div>
+              <span className="text-sm text-slate-400">
+                {room.occupants.length} {room.occupants.length === 1 ? "person" : "people"}
+              </span>
+            </div>
+            <div className="mt-5 aspect-square rounded-2xl border border-slate-800/60 bg-gradient-to-br from-slate-950 via-slate-900 to-slate-950">
+              <div className="relative h-full w-full">
+                <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.08),_transparent_60%)]" />
+                {room.occupants.map((person) => {
+                  const x = clamp(person.centroid[0] * 100, 5, 95);
+                  const y = clamp(person.centroid[1] * 100, 5, 95);
+                  return (
+                    <div
+                      key={person.trackId}
+                      className="absolute flex h-8 w-8 -translate-x-1/2 -translate-y-1/2 items-center justify-center rounded-full bg-indigo-500/70 text-xs font-semibold text-white shadow-lg shadow-indigo-500/30"
+                      style={{ left: `${x}%`, top: `${y}%` }}
+                    >
+                      #{person.trackId}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+            <div className="mt-4 space-y-2 text-xs text-slate-500">
+              {room.occupants.length === 0 ? (
+                <p>No presence detected.</p>
+              ) : (
+                room.occupants.map((person) => {
+                  const secondsAgo = Math.round((Date.now() - person.lastSeen) / 1000);
+                  return (
+                    <div key={`meta-${person.trackId}`} className="flex justify-between">
+                      <span className="font-medium text-slate-300">Track #{person.trackId}</span>
+                      <span>{secondsAgo <= 1 ? "moments ago" : `${secondsAgo}s ago`}</span>
+                    </div>
+                  );
+                })
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default LivePresenceFeed;
+

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -1,0 +1,81 @@
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
+
+import { useAuthActions, useAuthStatus } from "../../lib/useAuth";
+
+const navItems = [
+  { label: "Dashboard", to: "/dashboard" },
+  { label: "Spaces", to: "/spaces" }
+];
+
+const AppShell: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const location = useLocation();
+  const { data } = useAuthStatus();
+  const { logout } = useAuthActions();
+
+  const handleLogout = async () => {
+    try {
+      await logout.mutateAsync();
+    } catch (error) {
+      // eslint-disable-next-line no-console
+      console.error("Failed to sign out", error);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0 overflow-hidden">
+        <div className="pointer-events-none absolute -top-64 right-1/2 h-96 w-96 translate-x-1/2 rounded-full bg-indigo-500/20 blur-3xl" />
+        <div className="pointer-events-none absolute bottom-0 left-1/3 h-72 w-72 -translate-x-1/2 rounded-full bg-sky-500/10 blur-3xl" />
+      </div>
+      <header className="relative border-b border-slate-800/60 bg-slate-950/70 backdrop-blur">
+        <div className="mx-auto flex max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
+          <Link to="/dashboard" className="flex items-center gap-3 text-lg font-semibold tracking-wide">
+            <span className="flex h-10 w-10 items-center justify-center rounded-2xl bg-indigo-500/20 text-base font-bold text-indigo-300">
+              AI
+            </span>
+            Altinet Control
+          </Link>
+          <nav className="flex items-center gap-3 text-sm">
+            {navItems.map((item) => {
+              const isActive = location.pathname.startsWith(item.to);
+              return (
+                <Link
+                  key={item.to}
+                  to={item.to}
+                  className={`rounded-full px-4 py-2 transition ${
+                    isActive
+                      ? "bg-slate-800/90 text-white shadow-inner"
+                      : "text-slate-400 hover:bg-slate-800/60 hover:text-white"
+                  }`}
+                >
+                  {item.label}
+                </Link>
+              );
+            })}
+          </nav>
+          <div className="flex items-center gap-4 text-sm">
+            {data?.user && (
+              <div className="hidden text-right md:block">
+                <p className="font-medium text-slate-200">{data.user.username}</p>
+                <p className="text-xs text-slate-500">Operator</p>
+              </div>
+            )}
+            <button
+              type="button"
+              onClick={handleLogout}
+              disabled={logout.isPending}
+              className="rounded-full border border-slate-700/70 px-4 py-2 text-sm font-medium text-slate-300 transition hover:border-slate-500 hover:text-white disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {logout.isPending ? "Signing out…" : "Sign out"}
+            </button>
+          </div>
+        </div>
+      </header>
+      <main className="relative z-10 mx-auto w-full max-w-6xl px-6 py-10">{children}</main>
+    </div>
+  );
+};
+
+export default AppShell;
+

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -4,10 +4,50 @@ const API_BASE = import.meta.env.VITE_API_URL ?? "http://localhost:8000/api";
 
 export const api = axios.create({
   baseURL: API_BASE,
+  withCredentials: true,
   headers: {
     "Content-Type": "application/json"
   }
 });
+
+export interface AuthUser {
+  id: string;
+  username: string;
+  first_name: string;
+  last_name: string;
+  email: string;
+}
+
+export interface AuthStatus {
+  has_users: boolean;
+  is_authenticated: boolean;
+  user: AuthUser | null;
+}
+
+export async function fetchAuthStatus() {
+  const response = await api.get<AuthStatus>("/auth/status/");
+  return response.data;
+}
+
+export async function registerUser(payload: {
+  username: string;
+  password: string;
+  email?: string;
+  first_name?: string;
+  last_name?: string;
+}) {
+  const response = await api.post<AuthUser>("/auth/register/", payload);
+  return response.data;
+}
+
+export async function loginUser(payload: { username: string; password: string }) {
+  const response = await api.post<AuthUser>("/auth/login/", payload);
+  return response.data;
+}
+
+export async function logoutUser() {
+  await api.post("/auth/logout/");
+}
 
 export interface Room {
   id: string;

--- a/frontend/src/lib/useAuth.ts
+++ b/frontend/src/lib/useAuth.ts
@@ -1,0 +1,57 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import {
+  AuthStatus,
+  fetchAuthStatus,
+  loginUser,
+  logoutUser,
+  registerUser
+} from "./api";
+
+export const authQueryKey = ["auth", "status"] as const;
+
+export function useAuthStatus() {
+  return useQuery({ queryKey: authQueryKey, queryFn: fetchAuthStatus, staleTime: 30_000 });
+}
+
+export function useAuthActions() {
+  const queryClient = useQueryClient();
+
+  const register = useMutation({
+    mutationFn: registerUser,
+    onSuccess: (user) => {
+      const next: AuthStatus = {
+        has_users: true,
+        is_authenticated: true,
+        user
+      };
+      queryClient.setQueryData(authQueryKey, next);
+    }
+  });
+
+  const login = useMutation({
+    mutationFn: loginUser,
+    onSuccess: (user) => {
+      const next: AuthStatus = {
+        has_users: true,
+        is_authenticated: true,
+        user
+      };
+      queryClient.setQueryData(authQueryKey, next);
+    }
+  });
+
+  const logout = useMutation({
+    mutationFn: logoutUser,
+    onSuccess: () => {
+      queryClient.setQueryData<AuthStatus | undefined>(authQueryKey, (prev) => ({
+        has_users: prev?.has_users ?? true,
+        is_authenticated: false,
+        user: null
+      }));
+    }
+  });
+
+  return { register, login, logout };
+}
+

--- a/frontend/src/lib/ws.ts
+++ b/frontend/src/lib/ws.ts
@@ -10,6 +10,21 @@ export type CalibrationMessage = {
   msg: string;
 };
 
+export type PersonTrackMessage = {
+  event: "TRACK";
+  room_id: string;
+  track_id: string;
+  centroid?: [number, number];
+  timestamp?: string;
+};
+
+export type RoomPresenceMessage = {
+  event: "PRESENCE";
+  room_id: string;
+  track_ids: string[];
+  timestamp?: string;
+};
+
 const WS_BASE = (import.meta.env.VITE_WS_URL as string | undefined) ?? "ws://localhost:8000";
 
 export function createCameraHealthSocket(onMessage: (msg: CameraHealthMessage) => void) {
@@ -22,6 +37,14 @@ export function createCameraHealthSocket(onMessage: (msg: CameraHealthMessage) =
 
 export function createCalibrationSocket(cameraId: string, onMessage: (msg: CalibrationMessage) => void) {
   const socket = new WebSocket(`${WS_BASE}/ws/calibration/${cameraId}`);
+  socket.onmessage = (event) => onMessage(JSON.parse(event.data));
+  return socket;
+}
+
+export function createPersonTrackSocket(
+  onMessage: (msg: PersonTrackMessage | RoomPresenceMessage) => void
+) {
+  const socket = new WebSocket(`${WS_BASE}/ws/tracks/`);
   socket.onmessage = (event) => onMessage(JSON.parse(event.data));
   return socket;
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -4,15 +4,38 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Navigate, Route, Routes } from "react-router-dom";
 
 import "./index.css";
+import LandingPage from "./pages/home";
+import LoginPage from "./pages/auth/login";
+import RegisterPage from "./pages/auth/register";
+import DashboardPage from "./pages/dashboard";
 import SpacesPage from "./pages/spaces";
+import RequireAuth from "./components/auth/RequireAuth";
 
 const queryClient = new QueryClient();
 
 const App = () => (
   <BrowserRouter>
     <Routes>
-      <Route path="/spaces" element={<SpacesPage />} />
-      <Route path="*" element={<Navigate to="/spaces" replace />} />
+      <Route path="/" element={<LandingPage />} />
+      <Route path="/login" element={<LoginPage />} />
+      <Route path="/register" element={<RegisterPage />} />
+      <Route
+        path="/dashboard"
+        element={
+          <RequireAuth>
+            <DashboardPage />
+          </RequireAuth>
+        }
+      />
+      <Route
+        path="/spaces"
+        element={
+          <RequireAuth>
+            <SpacesPage />
+          </RequireAuth>
+        }
+      />
+      <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>
   </BrowserRouter>
 );

--- a/frontend/src/pages/auth/login.tsx
+++ b/frontend/src/pages/auth/login.tsx
@@ -1,0 +1,102 @@
+import React, { FormEvent, useState } from "react";
+import { Link, Navigate, useLocation } from "react-router-dom";
+
+import { useAuthActions, useAuthStatus } from "../../lib/useAuth";
+
+const LoginPage: React.FC = () => {
+  const { data, isLoading } = useAuthStatus();
+  const { login } = useAuthActions();
+  const location = useLocation();
+  const [credentials, setCredentials] = useState({ username: "", password: "" });
+  const [error, setError] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-100">
+        <span className="text-sm uppercase tracking-[0.4em] text-slate-500">Loading…</span>
+      </div>
+    );
+  }
+
+  if (!data?.has_users) {
+    return <Navigate to="/register" replace />;
+  }
+
+  if (data?.is_authenticated) {
+    const redirectTo = (location.state as { from?: string } | null)?.from ?? "/dashboard";
+    return <Navigate to={redirectTo} replace />;
+  }
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      await login.mutateAsync(credentials);
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === "string" ? detail : "Incorrect username or password.");
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-40 right-1/3 h-72 w-72 rounded-full bg-indigo-500/20 blur-3xl" />
+        <div className="absolute bottom-0 left-16 h-96 w-96 rounded-full bg-sky-500/10 blur-3xl" />
+      </div>
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-3xl flex-col justify-center px-6 py-16">
+        <div className="mb-10 text-sm text-slate-400">
+          <Link to="/" className="text-indigo-300 transition hover:text-indigo-200">← Back to overview</Link>
+        </div>
+        <h1 className="text-3xl font-semibold text-slate-50 md:text-4xl">Sign in to continue</h1>
+        <p className="mt-3 max-w-xl text-base text-slate-400">
+          Access the Altinet dashboard to view live presence, manage rooms and calibrate cameras.
+        </p>
+        <form onSubmit={handleSubmit} className="mt-10 grid gap-6 rounded-3xl border border-slate-800/60 bg-slate-900/60 p-10 backdrop-blur">
+          <div className="grid gap-2">
+            <label htmlFor="username" className="text-sm font-medium text-slate-200">
+              Username
+            </label>
+            <input
+              id="username"
+              name="username"
+              required
+              value={credentials.username}
+              onChange={(event) => setCredentials((prev) => ({ ...prev, username: event.target.value }))}
+              className="rounded-xl border border-slate-700/60 bg-slate-950/60 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-indigo-400 focus:outline-none"
+              placeholder="operator"
+              autoComplete="username"
+            />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="password" className="text-sm font-medium text-slate-200">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              value={credentials.password}
+              onChange={(event) => setCredentials((prev) => ({ ...prev, password: event.target.value }))}
+              className="rounded-xl border border-slate-700/60 bg-slate-950/60 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-indigo-400 focus:outline-none"
+              placeholder="••••••••"
+              autoComplete="current-password"
+            />
+          </div>
+          {error && <p className="text-sm text-rose-300/80">{error}</p>}
+          <button
+            type="submit"
+            disabled={login.isPending}
+            className="mt-4 inline-flex items-center justify-center rounded-full bg-indigo-500 px-8 py-3 text-sm font-semibold uppercase tracking-wider text-white shadow-lg shadow-indigo-500/30 transition hover:shadow-indigo-500/50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {login.isPending ? "Signing in…" : "Sign in"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;
+

--- a/frontend/src/pages/auth/register.tsx
+++ b/frontend/src/pages/auth/register.tsx
@@ -1,0 +1,157 @@
+import React, { FormEvent, useState } from "react";
+import { Link, Navigate } from "react-router-dom";
+
+import { useAuthActions, useAuthStatus } from "../../lib/useAuth";
+
+const RegisterPage: React.FC = () => {
+  const { data, isLoading } = useAuthStatus();
+  const { register } = useAuthActions();
+  const [form, setForm] = useState({
+    username: "",
+    password: "",
+    email: "",
+    first_name: "",
+    last_name: ""
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-100">
+        <span className="text-sm uppercase tracking-[0.4em] text-slate-500">Loading…</span>
+      </div>
+    );
+  }
+
+  if (data?.is_authenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  if (data?.has_users) {
+    return <Navigate to="/login" replace />;
+  }
+
+  const handleSubmit = async (event: FormEvent) => {
+    event.preventDefault();
+    setError(null);
+    try {
+      await register.mutateAsync({
+        username: form.username,
+        password: form.password,
+        email: form.email || undefined,
+        first_name: form.first_name || undefined,
+        last_name: form.last_name || undefined
+      });
+    } catch (err: any) {
+      const detail = err?.response?.data?.detail;
+      setError(typeof detail === "string" ? detail : "Could not create your account. Please try again.");
+    }
+  };
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-56 left-24 h-80 w-80 rounded-full bg-indigo-500/20 blur-3xl" />
+        <div className="absolute bottom-10 right-0 h-96 w-96 rounded-full bg-sky-500/10 blur-3xl" />
+      </div>
+      <div className="relative z-10 mx-auto flex min-h-screen w-full max-w-4xl flex-col justify-center px-6 py-16">
+        <div className="mb-10 text-sm text-slate-400">
+          <Link to="/" className="text-indigo-300 transition hover:text-indigo-200">← Back to overview</Link>
+        </div>
+        <h1 className="text-3xl font-semibold text-slate-50 md:text-4xl">Create the first operator</h1>
+        <p className="mt-3 max-w-xl text-base text-slate-400">
+          This account manages the entire perception stack. Choose a strong password and keep it secure.
+        </p>
+        <form onSubmit={handleSubmit} className="mt-10 grid gap-6 rounded-3xl border border-slate-800/60 bg-slate-900/60 p-10 backdrop-blur">
+          <div className="grid gap-2">
+            <label htmlFor="username" className="text-sm font-medium text-slate-200">
+              Username
+            </label>
+            <input
+              id="username"
+              name="username"
+              required
+              value={form.username}
+              onChange={(event) => setForm((prev) => ({ ...prev, username: event.target.value }))}
+              className="rounded-xl border border-slate-700/60 bg-slate-950/60 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-indigo-400 focus:outline-none"
+              placeholder="operator"
+              autoComplete="username"
+            />
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="password" className="text-sm font-medium text-slate-200">
+              Password
+            </label>
+            <input
+              id="password"
+              name="password"
+              type="password"
+              required
+              value={form.password}
+              onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+              className="rounded-xl border border-slate-700/60 bg-slate-950/60 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-indigo-400 focus:outline-none"
+              placeholder="••••••••"
+              autoComplete="new-password"
+            />
+          </div>
+          <div className="grid gap-2 sm:grid-cols-2 sm:gap-6">
+            <div className="grid gap-2">
+              <label htmlFor="first_name" className="text-sm font-medium text-slate-200">
+                First name (optional)
+              </label>
+              <input
+                id="first_name"
+                name="first_name"
+                value={form.first_name}
+                onChange={(event) => setForm((prev) => ({ ...prev, first_name: event.target.value }))}
+                className="rounded-xl border border-slate-700/60 bg-slate-950/60 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-indigo-400 focus:outline-none"
+                placeholder="Alex"
+                autoComplete="given-name"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label htmlFor="last_name" className="text-sm font-medium text-slate-200">
+                Last name (optional)
+              </label>
+              <input
+                id="last_name"
+                name="last_name"
+                value={form.last_name}
+                onChange={(event) => setForm((prev) => ({ ...prev, last_name: event.target.value }))}
+                className="rounded-xl border border-slate-700/60 bg-slate-950/60 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-indigo-400 focus:outline-none"
+                placeholder="Rivera"
+                autoComplete="family-name"
+              />
+            </div>
+          </div>
+          <div className="grid gap-2">
+            <label htmlFor="email" className="text-sm font-medium text-slate-200">
+              Email (optional)
+            </label>
+            <input
+              id="email"
+              name="email"
+              type="email"
+              value={form.email}
+              onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+              className="rounded-xl border border-slate-700/60 bg-slate-950/60 px-4 py-3 text-slate-100 placeholder:text-slate-500 focus:border-indigo-400 focus:outline-none"
+              placeholder="ops@example.com"
+              autoComplete="email"
+            />
+          </div>
+          {error && <p className="text-sm text-rose-300/80">{error}</p>}
+          <button
+            type="submit"
+            disabled={register.isPending}
+            className="mt-4 inline-flex items-center justify-center rounded-full bg-indigo-500 px-8 py-3 text-sm font-semibold uppercase tracking-wider text-white shadow-lg shadow-indigo-500/30 transition hover:shadow-indigo-500/50 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {register.isPending ? "Creating…" : "Create account"}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default RegisterPage;
+

--- a/frontend/src/pages/dashboard/index.tsx
+++ b/frontend/src/pages/dashboard/index.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { useQuery } from "@tanstack/react-query";
+
+import AppShell from "../../components/layout/AppShell";
+import LivePresenceFeed from "../../components/dashboard/LivePresenceFeed";
+import { listRooms } from "../../lib/api";
+import { useAuthStatus } from "../../lib/useAuth";
+
+const DashboardPage: React.FC = () => {
+  const { data: auth } = useAuthStatus();
+  const { data: rooms = [], isLoading } = useQuery({ queryKey: ["rooms"], queryFn: listRooms });
+
+  return (
+    <AppShell>
+      <section className="space-y-12">
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-900/60 p-8 text-slate-100 shadow-[0_0_45px_-30px_rgba(79,70,229,0.8)]">
+          <p className="text-sm uppercase tracking-[0.5em] text-indigo-200/80">Control centre</p>
+          <h1 className="mt-4 text-3xl font-semibold md:text-4xl">
+            {auth?.user ? `Welcome back, ${auth.user.first_name || auth.user.username}` : "Altinet dashboard"}
+          </h1>
+          <p className="mt-4 max-w-3xl text-sm text-slate-400 md:text-base">
+            Monitor detections, confirm occupancy and orchestrate your sensing network. The live feed below shows every track broadcast by the perception stack in real time.
+          </p>
+        </div>
+        {isLoading ? (
+          <div className="flex min-h-[320px] items-center justify-center rounded-3xl border border-slate-800/60 bg-slate-900/60 text-sm uppercase tracking-[0.4em] text-slate-500">
+            Loading rooms…
+          </div>
+        ) : (
+          <LivePresenceFeed rooms={rooms} />
+        )}
+      </section>
+    </AppShell>
+  );
+};
+
+export default DashboardPage;
+

--- a/frontend/src/pages/home/index.tsx
+++ b/frontend/src/pages/home/index.tsx
@@ -1,0 +1,67 @@
+import React from "react";
+import { Link, Navigate } from "react-router-dom";
+
+import { useAuthStatus } from "../../lib/useAuth";
+
+const LandingPage: React.FC = () => {
+  const { data, isLoading, error } = useAuthStatus();
+  const hasError = Boolean(error);
+
+  if (isLoading) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-950 text-slate-100">
+        <span className="text-sm uppercase tracking-[0.4em] text-slate-500">Loading…</span>
+      </div>
+    );
+  }
+
+  if (data?.is_authenticated) {
+    return <Navigate to="/dashboard" replace />;
+  }
+
+  if (data?.has_users) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return (
+    <div className="relative min-h-screen overflow-hidden bg-slate-950 text-slate-100">
+      <div className="pointer-events-none absolute inset-0">
+        <div className="absolute -top-40 left-1/2 h-[28rem] w-[28rem] -translate-x-1/2 rounded-full bg-indigo-500/20 blur-3xl" />
+        <div className="absolute bottom-10 right-20 h-72 w-72 rounded-full bg-sky-500/10 blur-3xl" />
+      </div>
+      <main className="relative z-10 mx-auto flex min-h-screen max-w-4xl flex-col items-center justify-center px-6 py-16 text-center">
+        <span className="mb-6 rounded-full border border-indigo-500/30 bg-indigo-500/10 px-4 py-1 text-xs uppercase tracking-[0.4em] text-indigo-200">
+          Welcome to Altinet
+        </span>
+        <h1 className="text-4xl font-semibold leading-tight text-slate-50 md:text-5xl">
+          Secure perception for intelligent homes
+        </h1>
+        <p className="mt-6 max-w-2xl text-base text-slate-400 md:text-lg">
+          Altinet orchestrates cameras, tracking and identity services so you can monitor every room with confidence. Create the first operator account to begin configuring rooms, calibrating cameras and visualising live presence.
+        </p>
+        {hasError && (
+          <p className="mt-6 text-sm text-rose-300/80">
+            Unable to contact the server. Please check your connection and try again.
+          </p>
+        )}
+        <div className="mt-12 flex flex-col gap-4 sm:flex-row">
+          <Link
+            to="/register"
+            className="inline-flex items-center justify-center rounded-full bg-indigo-500 px-8 py-3 text-sm font-semibold uppercase tracking-wider text-white shadow-lg shadow-indigo-500/30 transition hover:shadow-indigo-500/50"
+          >
+            Create operator account
+          </Link>
+          <Link
+            to="/login"
+            className="inline-flex items-center justify-center rounded-full border border-slate-700/60 px-8 py-3 text-sm font-semibold uppercase tracking-wider text-slate-200 transition hover:border-slate-500 hover:text-white"
+          >
+            Already onboarded? Sign in
+          </Link>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default LandingPage;
+

--- a/frontend/src/pages/spaces/index.tsx
+++ b/frontend/src/pages/spaces/index.tsx
@@ -16,6 +16,7 @@ import {
   updateRoom
 } from "../../lib/api";
 import { createCameraHealthSocket } from "../../lib/ws";
+import AppShell from "../../components/layout/AppShell";
 import RoomListPanel from "../../components/spaces/RoomListPanel";
 import RoomEditor from "../../components/spaces/RoomEditor";
 import CameraList from "../../components/spaces/CameraList";
@@ -166,13 +167,14 @@ const SpacesPage: React.FC = () => {
   };
 
   return (
-    <div className="flex min-h-screen flex-col gap-6 bg-slate-950 p-8 text-slate-100">
-      <header>
-        <h1 className="text-2xl font-semibold">Spaces &amp; Cameras</h1>
-        <p className="text-sm text-slate-400">Configure rooms, place cameras and run calibrations.</p>
-      </header>
+    <AppShell>
+      <div className="space-y-6 pb-12 text-slate-100">
+        <header>
+          <h1 className="text-2xl font-semibold">Spaces &amp; Cameras</h1>
+          <p className="text-sm text-slate-400">Configure rooms, place cameras and run calibrations.</p>
+        </header>
 
-      <nav className="flex gap-3">
+        <nav className="flex gap-3">
         {Tabs.map((label) => (
           <button
             key={label}
@@ -184,9 +186,9 @@ const SpacesPage: React.FC = () => {
             {label}
           </button>
         ))}
-      </nav>
+        </nav>
 
-      {tab === "Rooms" && (
+        {tab === "Rooms" && (
         <div className="grid gap-6 lg:grid-cols-[300px,1fr]">
           <RoomListPanel
             rooms={rooms}
@@ -228,7 +230,7 @@ const SpacesPage: React.FC = () => {
         </div>
       )}
 
-      {tab === "Cameras" && (
+        {tab === "Cameras" && (
         <div className="grid gap-6 lg:grid-cols-[1fr,400px]">
           <div className="rounded border border-slate-800 bg-slate-900 p-6">
             <div className="mb-4 flex items-center justify-between">
@@ -280,7 +282,7 @@ const SpacesPage: React.FC = () => {
         </div>
       )}
 
-      {tab === "Calibration" && (
+        {tab === "Calibration" && (
         <div className="grid gap-6 lg:grid-cols-[1fr,350px]">
           <div className="rounded border border-slate-800 bg-slate-900 p-6">
             <CalibrationWizard
@@ -297,8 +299,9 @@ const SpacesPage: React.FC = () => {
             <CalibrationRunsTable runs={calibrationRuns} />
           </div>
         </div>
-      )}
-    </div>
+        )}
+      </div>
+    </AppShell>
   );
 };
 


### PR DESCRIPTION
## Summary
- add CSRF-exempt session authentication endpoints alongside event ingestion for live track updates
- broadcast person-track and presence messages over a dedicated websocket channel and cover the new APIs with tests
- refresh the frontend with a landing page, login/register flows, an authenticated dashboard with live presence visualisation, and wrap the spaces tools in a shared shell

## Testing
- PYTHONPATH=. pytest
- npm run build *(fails: missing dev dependency @vitejs/plugin-react in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d47df9f128832fb76d6724ed30914f