### PR TITLE
Serve dashboard from Django root view

### DIFF
--- a/backend/altinet_backend/tests/test_dashboard.py
+++ b/backend/altinet_backend/tests/test_dashboard.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from django.urls import resolve
+
+
+def test_dashboard_view_renders_with_expected_content(client):
+    response = client.get("/")
+    assert response.status_code == 200
+    html = response.content.decode("utf-8")
+    assert "Altinet Dashboard" in html
+    assert "Manage Spaces" in html
+    assert "API Reference" in html
+
+
+def test_dashboard_url_maps_to_dashboard_view():
+    match = resolve("/")
+    assert match.view_name == "dashboard"

--- a/backend/altinet_backend/urls.py
+++ b/backend/altinet_backend/urls.py
@@ -6,7 +6,10 @@ from django.contrib import admin
 from django.urls import include, path
 from drf_spectacular.views import SpectacularAPIView, SpectacularSwaggerView
 
+from .views import DashboardView
+
 urlpatterns = [
+    path("", DashboardView.as_view(), name="dashboard"),
     path("admin/", admin.site.urls),
     path("api/schema/", SpectacularAPIView.as_view(), name="schema"),
     path(

--- a/backend/altinet_backend/views.py
+++ b/backend/altinet_backend/views.py
@@ -1,0 +1,48 @@
+"""Site-level views for the Altinet Django project."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.views.generic import TemplateView
+
+
+class DashboardView(TemplateView):
+    """Render the primary dashboard landing page."""
+
+    template_name = "dashboard/index.html"
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
+        context = super().get_context_data(**kwargs)
+        context.update(
+            {
+                "primary_links": [
+                    {
+                        "href": "/spaces/",
+                        "label": "Manage Spaces",
+                        "description": "Create rooms, configure cameras, and review calibration runs.",
+                    },
+                    {
+                        "href": "/api/docs/",
+                        "label": "API Reference",
+                        "description": "Explore the REST endpoints backing the Altinet platform.",
+                    },
+                    {
+                        "href": "/admin/",
+                        "label": "Admin Site",
+                        "description": "Manage Django auth users, permissions, and persisted resources.",
+                    },
+                ],
+                "coming_soon": [
+                    {
+                        "label": "Presence Monitor",
+                        "description": "Real-time view of who is currently detected across all rooms.",
+                    },
+                    {
+                        "label": "Face Gallery",
+                        "description": "Browse captured embeddings and snapshots from recent events.",
+                    },
+                ],
+            }
+        )
+        return context

--- a/backend/templates/dashboard/index.html
+++ b/backend/templates/dashboard/index.html
@@ -1,0 +1,202 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Altinet Dashboard</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+
+      body {
+        margin: 0;
+        padding: 0;
+        min-height: 100vh;
+        background: radial-gradient(circle at top left, #f8fafc, #e2e8f0);
+        color: #0f172a;
+        display: flex;
+        flex-direction: column;
+      }
+
+      header {
+        padding: 3rem 1.5rem 1rem;
+        text-align: center;
+      }
+
+      header h1 {
+        margin: 0;
+        font-size: clamp(2rem, 3vw, 2.75rem);
+      }
+
+      header p {
+        margin: 0.75rem auto 0;
+        max-width: 40rem;
+        color: #475569;
+        line-height: 1.6;
+      }
+
+      main {
+        flex: 1;
+        display: grid;
+        gap: 2rem;
+        padding: 0 1.5rem 3rem;
+        max-width: 70rem;
+        width: 100%;
+        margin: 0 auto;
+        box-sizing: border-box;
+      }
+
+      section {
+        background: rgba(255, 255, 255, 0.8);
+        border-radius: 1.5rem;
+        padding: 2rem;
+        box-shadow: 0 20px 40px rgba(15, 23, 42, 0.08);
+        backdrop-filter: blur(16px);
+      }
+
+      h2 {
+        margin-top: 0;
+        font-size: 1.25rem;
+        color: #0f172a;
+      }
+
+      ul {
+        list-style: none;
+        margin: 1.5rem 0 0;
+        padding: 0;
+        display: grid;
+        gap: 1.25rem;
+      }
+
+      li a {
+        display: block;
+        text-decoration: none;
+        padding: 1rem 1.25rem;
+        border-radius: 1rem;
+        background: linear-gradient(135deg, #2563eb, #7c3aed);
+        color: #fff;
+        font-weight: 600;
+        box-shadow: 0 16px 30px rgba(37, 99, 235, 0.25);
+        transition: transform 0.2s ease, box-shadow 0.2s ease;
+      }
+
+      li a:hover,
+      li a:focus {
+        transform: translateY(-4px);
+        box-shadow: 0 20px 40px rgba(124, 58, 237, 0.35);
+      }
+
+      li span {
+        display: block;
+        margin-top: 0.5rem;
+        font-weight: 400;
+        color: rgba(255, 255, 255, 0.9);
+      }
+
+      .pill {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        background: rgba(15, 23, 42, 0.08);
+        padding: 0.35rem 0.75rem;
+        border-radius: 999px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        letter-spacing: 0.04em;
+        text-transform: uppercase;
+        color: #2563eb;
+      }
+
+      .coming-card {
+        padding: 1.25rem 1.5rem;
+        border-radius: 1.25rem;
+        background: rgba(15, 23, 42, 0.04);
+        box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.06);
+      }
+
+      .coming-card h3 {
+        margin: 0.75rem 0 0.5rem;
+        font-size: 1.1rem;
+      }
+
+      .coming-card p {
+        margin: 0;
+        color: #475569;
+        line-height: 1.6;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        body {
+          background: radial-gradient(circle at top left, #1e293b, #0f172a);
+          color: #e2e8f0;
+        }
+
+        section {
+          background: rgba(15, 23, 42, 0.6);
+          box-shadow: 0 20px 40px rgba(2, 6, 23, 0.6);
+        }
+
+        header p {
+          color: #cbd5f5;
+        }
+
+        h2 {
+          color: #e2e8f0;
+        }
+
+        .pill {
+          background: rgba(148, 163, 184, 0.16);
+          color: #60a5fa;
+        }
+
+        .coming-card {
+          background: rgba(15, 23, 42, 0.35);
+          box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.2);
+        }
+
+        .coming-card p {
+          color: #cbd5f5;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <div class="pill">Altinet Platform</div>
+      <h1>Welcome back to your workspace</h1>
+      <p>
+        Jump into the tools that keep your environments running smoothly. Configure spaces,
+        review camera calibration, and monitor presence &mdash; all from one central hub.
+      </p>
+    </header>
+    <main>
+      <section aria-labelledby="dashboard-actions">
+        <h2 id="dashboard-actions">Start with the essentials</h2>
+        <ul>
+          {% for link in primary_links %}
+            <li>
+              <a href="{{ link.href }}">
+                {{ link.label }}
+                <span>{{ link.description }}</span>
+              </a>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+      <section aria-labelledby="coming-soon">
+        <h2 id="coming-soon">In development</h2>
+        <ul>
+          {% for item in coming_soon %}
+            <li class="coming-card">
+              <div class="pill">Coming Soon</div>
+              <h3>{{ item.label }}</h3>
+              <p>{{ item.description }}</p>
+            </li>
+          {% endfor %}
+        </ul>
+      </section>
+    </main>
+  </body>
+</html>

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = tests.django_settings
 python_files = tests.py test_*.py *_tests.py
-testpaths = backend/spaces/tests ros2_ws/src/altinet/altinet/tests
+testpaths = backend/altinet_backend/tests backend/spaces/tests ros2_ws/src/altinet/altinet/tests
 addopts = --maxfail=1 --disable-warnings


### PR DESCRIPTION
## Summary
- route the site root to a Django TemplateView-powered dashboard with curated navigation links
- keep the React SPA focused on /spaces by removing the dashboard route and dependency additions
- cover the landing page with pytest-django tests and register the backend test suite path

## Testing
- PYTHONPATH=$PWD pytest backend/altinet_backend/tests -q --ds=tests.django_settings

------
https://chatgpt.com/codex/tasks/task_e_68d63d890cf8832f962d7dd0705a3b47