### PR TITLE
Fix Django static URL prefix for staticfiles serving

### DIFF
--- a/backend/altinet_backend/settings.py
+++ b/backend/altinet_backend/settings.py
@@ -99,7 +99,7 @@ TIME_ZONE = "UTC"
 USE_I18N = True
 USE_TZ = True
 
-STATIC_URL = "static/"
+STATIC_URL = "/static/"
 STATIC_ROOT = BASE_DIR / "static"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 


### PR DESCRIPTION
## Summary
- ensure the Django STATIC_URL includes a leading slash so static asset requests resolve correctly

## Testing
- pytest backend/web/tests/test_views.py

------
https://chatgpt.com/codex/tasks/task_e_68d8e4b4d3ac832f9957cd7a9d5e1331