### PR TITLE
Default Django debug to true for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Django backend for dashboards and historical analysis.
    python scripts/run_demo.py path/to/video.mp4 --room living_room
    ```
 
+### Production deployments
+
+The Django backend defaults to debug mode so local `runserver` instances serve
+static assets without extra configuration. When deploying to production
+environments you should explicitly disable debug behaviour by setting
+`DJANGO_DEBUG=false` in the deployment's environment configuration.
+
 ## Identity service walkthrough
 
 The identity service classifies each detection as a resident (`user`),

--- a/backend/altinet_backend/settings.py
+++ b/backend/altinet_backend/settings.py
@@ -14,7 +14,11 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 
 # Core configuration
 SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", get_random_secret_key())
-DEBUG = os.environ.get("DJANGO_DEBUG", "false").lower() == "true"
+# Default to Django debug mode in development unless explicitly disabled via
+# the environment. This keeps `runserver` behaviour (like serving static files
+# from `backend/web/static`) without requiring developers to set
+# `DJANGO_DEBUG=true`.
+DEBUG = os.environ.get("DJANGO_DEBUG", "true").lower() == "true"
 ALLOWED_HOSTS: list[str] = os.environ.get("DJANGO_ALLOWED_HOSTS", "*").split(",")
 
 # Applications


### PR DESCRIPTION
## Summary
- default the Django DEBUG flag to true so local runserver instances serve static assets without extra configuration
- document how production deployments can disable debug by setting `DJANGO_DEBUG=false`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d918839644832f88ae1232db8a42c3