### PR TITLE
Add multi-level floorplan workflow and Blender export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 *.pyc
 .venv/
 frontend/node_modules/
+backend/db.sqlite3

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Django backend for dashboards and historical analysis.
    python scripts/run_demo.py path/to/video.mp4 --room living_room
    ```
 
+### Builder → Blender → Dashboard workflow
+
+The browser-based builder now supports multi-level plans, local persistence and
+a one-click export for Blender. Follow the detailed guide in
+[`docs/workflows/floorplan_pipeline.md`](docs/workflows/floorplan_pipeline.md)
+to go from a sketched plan to the OBJ that powers the 3D viewer on the home page.
+
 ### Production deployments
 
 The Django backend defaults to debug mode so local `runserver` instances serve

--- a/backend/altinet_backend/settings.py
+++ b/backend/altinet_backend/settings.py
@@ -110,6 +110,11 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 LOGIN_REDIRECT_URL = "web:home"
 LOGOUT_REDIRECT_URL = "login"
 
+# Path to the OBJ model displayed on the dashboard viewer. Overridable via
+# ALTINET_HOME_MODEL environment variable so Blender exports can update the
+# served asset without touching templates.
+HOME_MODEL_STATIC_PATH = os.environ.get("ALTINET_HOME_MODEL", "web/models/home.obj")
+
 # REST Framework
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",

--- a/backend/templates/web/builder.html
+++ b/backend/templates/web/builder.html
@@ -6,7 +6,23 @@
 <div class="row g-4">
   <div class="col-12 col-lg-8">
     <div class="card shadow-sm h-100">
-      <div class="card-header bg-dark text-white">Floorplan Builder</div>
+      <div class="card-header bg-dark text-white d-flex flex-column flex-xl-row gap-3 align-items-start align-items-xl-center justify-content-between">
+        <div>
+          <div class="d-flex align-items-center gap-2">
+            <span class="fw-semibold">Floorplan Builder</span>
+            <span class="badge text-bg-secondary" id="activeLevelLabel">Level 1</span>
+          </div>
+          <p class="small mb-0 text-white-50">
+            Switch between levels to sketch multi-storey layouts. Changes are saved locally in your browser.
+          </p>
+        </div>
+        <div class="d-flex flex-wrap gap-2">
+          <div class="btn-group" role="group" aria-label="Levels" id="levelTabs"></div>
+          <button type="button" class="btn btn-outline-light btn-sm" id="addLevel">
+            Add level
+          </button>
+        </div>
+      </div>
       <div class="card-body">
         <div class="d-flex flex-column flex-md-row justify-content-between align-items-start align-items-md-center gap-3 mb-3">
           <div class="btn-group" role="group" aria-label="Builder tools">
@@ -22,7 +38,7 @@
               Undo last
             </button>
             <button type="button" class="btn btn-outline-danger" id="clearCanvas">
-              Clear all
+              Clear level
             </button>
           </div>
         </div>
@@ -34,11 +50,30 @@
             class="w-100 h-auto"
           ></canvas>
         </div>
-        <p class="text-muted small mt-3 mb-0">
-          Use the wall tool to draw structural lines that snap to the grid. Switch to
-          the room tool to drag out rectangular rooms and give them names. All data is
-          kept in your browser for now.
-        </p>
+        <div class="d-flex flex-column flex-lg-row gap-3 mt-3">
+          <div class="flex-grow-1">
+            <label for="levelName" class="form-label small text-uppercase fw-semibold text-secondary">
+              Active level name
+            </label>
+            <input type="text" class="form-control" id="levelName" placeholder="e.g. Ground floor" maxlength="40" />
+          </div>
+          <div class="flex-shrink-0 d-flex flex-column gap-2">
+            <button type="button" class="btn btn-outline-secondary" id="duplicateLevel">
+              Duplicate level
+            </button>
+            <button type="button" class="btn btn-outline-danger" id="deleteLevel">
+              Delete level
+            </button>
+          </div>
+        </div>
+        <div class="alert alert-info mt-3 mb-0" role="alert">
+          <h2 class="h6 fw-semibold mb-2">Workflow</h2>
+          <ol class="mb-0 small ps-3">
+            <li>Sketch each storey of the property using the tools above and switch levels as needed.</li>
+            <li>Export the floorplan once you are happy. The export contains geometry that Blender can read.</li>
+            <li>Open the exported JSON in Blender with <code>scripts/generate_floorplan.py</code> to create the 3D model shown on the dashboard.</li>
+          </ol>
+        </div>
       </div>
     </div>
   </div>
@@ -47,10 +82,15 @@
       <div class="card-header bg-dark text-white">Rooms</div>
       <div class="card-body d-flex flex-column">
         <p class="text-muted small">
-          Rooms you define are listed here with their grid dimensions. Use this as a
-          quick reference while sketching your layout.
+          Rooms you define are listed here with their grid dimensions. Use this as a quick reference while sketching your layout.
         </p>
         <ul class="list-group flex-grow-1" id="roomList"></ul>
+        <div class="mt-3">
+          <button type="button" class="btn btn-primary w-100" id="exportPlan">Export plan for Blender</button>
+          <p class="small text-muted mt-2 mb-0">
+            Exports to <code>.json</code> with every wall and room per level. Import it via Blender: <code>blender --python scripts/generate_floorplan.py -- --plan &lt;file&gt; --obj-out assets/home.obj</code>.
+          </p>
+        </div>
       </div>
     </div>
   </div>
@@ -61,8 +101,10 @@
     const canvas = document.getElementById("builderCanvas");
     const ctx = canvas.getContext("2d");
     const gridSize = 30;
-    const walls = [];
-    const rooms = [];
+    const storageKey = "altinet-floorplan";
+    const defaultUnitScale = 0.5; // metres per grid unit
+    let levels = [];
+    let activeLevelId = null;
     let isDrawing = false;
     let startPoint = null;
     let previewPoint = null;
@@ -72,6 +114,13 @@
     const roomList = document.getElementById("roomList");
     const clearButton = document.getElementById("clearCanvas");
     const undoButton = document.getElementById("undoLast");
+    const levelTabs = document.getElementById("levelTabs");
+    const levelNameInput = document.getElementById("levelName");
+    const addLevelButton = document.getElementById("addLevel");
+    const duplicateLevelButton = document.getElementById("duplicateLevel");
+    const deleteLevelButton = document.getElementById("deleteLevel");
+    const exportPlanButton = document.getElementById("exportPlan");
+    const activeLevelBadge = document.getElementById("activeLevelLabel");
 
     function setActiveTool(tool) {
       activeTool = tool;
@@ -87,6 +136,95 @@
     toolButtons.forEach((button) => {
       button.addEventListener("click", () => setActiveTool(button.dataset.tool));
     });
+
+    function uuid() {
+      if (typeof crypto !== "undefined" && crypto.randomUUID) {
+        return crypto.randomUUID();
+      }
+      return `lvl-${Date.now()}-${Math.floor(Math.random() * 1000)}`;
+    }
+
+    function createLevel(name) {
+      return {
+        id: uuid(),
+        name,
+        walls: [],
+        rooms: [],
+      };
+    }
+
+    function loadState() {
+      try {
+        const stored = localStorage.getItem(storageKey);
+        if (!stored) {
+          const initialLevel = createLevel("Level 1");
+          levels = [initialLevel];
+          activeLevelId = initialLevel.id;
+          return;
+        }
+        const parsed = JSON.parse(stored);
+        if (!Array.isArray(parsed.levels) || parsed.levels.length === 0) {
+          throw new Error("Invalid stored plan");
+        }
+        levels = parsed.levels.map((level, index) => ({
+          id: level.id || uuid(),
+          name: level.name || `Level ${index + 1}`,
+          walls: Array.isArray(level.walls) ? level.walls : [],
+          rooms: Array.isArray(level.rooms) ? level.rooms : [],
+        }));
+        const storedActive = levels.find((level) => level.id === parsed.activeLevelId);
+        activeLevelId = storedActive ? storedActive.id : levels[0].id;
+      } catch (error) {
+        console.warn("Could not load saved plan, resetting", error);
+        const reset = createLevel("Level 1");
+        levels = [reset];
+        activeLevelId = reset.id;
+        localStorage.removeItem(storageKey);
+      }
+    }
+
+    function persistState() {
+      const payload = {
+        version: 1,
+        updatedAt: new Date().toISOString(),
+        activeLevelId,
+        levels,
+      };
+      localStorage.setItem(storageKey, JSON.stringify(payload));
+    }
+
+    function getActiveLevel() {
+      return levels.find((level) => level.id === activeLevelId) || null;
+    }
+
+    function setActiveLevel(levelId) {
+      const level = levels.find((item) => item.id === levelId);
+      if (!level) {
+        return;
+      }
+      activeLevelId = levelId;
+      levelNameInput.value = level.name;
+      activeLevelBadge.textContent = level.name;
+      updateLevelTabs();
+      updateRoomList();
+      render();
+      persistState();
+    }
+
+    function updateLevelTabs() {
+      levelTabs.innerHTML = "";
+      levels.forEach((level) => {
+        const button = document.createElement("button");
+        button.type = "button";
+        button.className = `btn btn-sm ${
+          level.id === activeLevelId ? "btn-primary" : "btn-outline-light"
+        }`;
+        button.textContent = level.name;
+        button.addEventListener("click", () => setActiveLevel(level.id));
+        levelTabs.appendChild(button);
+      });
+      deleteLevelButton.disabled = levels.length <= 1;
+    }
 
     function snapToGrid(clientX, clientY) {
       const rect = canvas.getBoundingClientRect();
@@ -122,7 +260,12 @@
 
     function renderRooms() {
       ctx.save();
-      rooms.forEach((room) => {
+      const level = getActiveLevel();
+      if (!level) {
+        ctx.restore();
+        return;
+      }
+      level.rooms.forEach((room) => {
         ctx.fillStyle = "rgba(13, 110, 253, 0.15)";
         ctx.strokeStyle = "rgba(13, 110, 253, 0.6)";
         ctx.lineWidth = 2;
@@ -142,7 +285,12 @@
       ctx.strokeStyle = "#343a40";
       ctx.lineWidth = 4;
       ctx.lineCap = "round";
-      walls.forEach((wall) => {
+      const level = getActiveLevel();
+      if (!level) {
+        ctx.restore();
+        return;
+      }
+      level.walls.forEach((wall) => {
         ctx.beginPath();
         ctx.moveTo(wall.start.x, wall.start.y);
         ctx.lineTo(wall.end.x, wall.end.y);
@@ -190,15 +338,16 @@
 
     function updateRoomList() {
       roomList.innerHTML = "";
-      if (rooms.length === 0) {
+      const level = getActiveLevel();
+      if (!level || level.rooms.length === 0) {
         const empty = document.createElement("li");
         empty.className = "list-group-item text-muted";
-        empty.textContent = "Draw a room to see it listed here.";
+        empty.textContent = "Draw a room on the active level to see it listed here.";
         roomList.appendChild(empty);
         return;
       }
 
-      rooms.forEach((room, index) => {
+      level.rooms.forEach((room, index) => {
         const li = document.createElement("li");
         li.className = "list-group-item d-flex justify-content-between align-items-center";
         const widthUnits = Math.round((room.width / gridSize) * 100) / 100;
@@ -229,25 +378,35 @@
       if (!startPoint || (startPoint.x === endPoint.x && startPoint.y === endPoint.y)) {
         return;
       }
-      walls.push({ start: { ...startPoint }, end: { ...endPoint } });
+      const level = getActiveLevel();
+      if (!level) {
+        return;
+      }
+      level.walls.push({ start: { ...startPoint }, end: { ...endPoint } });
+      persistState();
     }
 
     function createRoom(endPoint) {
       if (!startPoint || startPoint.x === endPoint.x || startPoint.y === endPoint.y) {
         return;
       }
+      const level = getActiveLevel();
+      if (!level) {
+        return;
+      }
       const x = Math.min(startPoint.x, endPoint.x);
       const y = Math.min(startPoint.y, endPoint.y);
       const width = Math.abs(endPoint.x - startPoint.x);
       const height = Math.abs(endPoint.y - startPoint.y);
-      const defaultName = `Room ${rooms.length + 1}`;
+      const defaultName = `Room ${level.rooms.length + 1}`;
       const enteredName = window.prompt("Name this room", defaultName);
       if (enteredName === null) {
         return;
       }
       const name = enteredName.trim() || defaultName;
-      rooms.push({ name, x, y, width, height });
+      level.rooms.push({ name, x, y, width, height });
       updateRoomList();
+      persistState();
     }
 
     function handlePointerUp(event) {
@@ -295,31 +454,130 @@
     canvas.addEventListener("touchcancel", handlePointerLeave);
 
     clearButton.addEventListener("click", () => {
-      walls.length = 0;
-      rooms.length = 0;
+      const level = getActiveLevel();
+      if (!level) {
+        return;
+      }
+      level.walls.length = 0;
+      level.rooms.length = 0;
       updateRoomList();
       render();
+      persistState();
     });
 
     undoButton.addEventListener("click", () => {
-      if (activeTool === "wall" && walls.length) {
-        walls.pop();
-      } else if (activeTool === "room" && rooms.length) {
-        rooms.pop();
+      const level = getActiveLevel();
+      if (!level) {
+        return;
+      }
+      if (activeTool === "wall" && level.walls.length) {
+        level.walls.pop();
+      } else if (activeTool === "room" && level.rooms.length) {
+        level.rooms.pop();
         updateRoomList();
-      } else if (walls.length) {
-        walls.pop();
-      } else if (rooms.length) {
-        rooms.pop();
+      } else if (level.walls.length) {
+        level.walls.pop();
+      } else if (level.rooms.length) {
+        level.rooms.pop();
         updateRoomList();
       }
       render();
+      persistState();
     });
 
     window.addEventListener("resize", render);
 
+    loadState();
+    updateLevelTabs();
+    setActiveLevel(activeLevelId);
     updateRoomList();
     render();
+
+    levelNameInput.addEventListener("input", (event) => {
+      const level = getActiveLevel();
+      if (!level) {
+        return;
+      }
+      const value = event.target.value.trim() || "Unnamed level";
+      level.name = value;
+      activeLevelBadge.textContent = value;
+      updateLevelTabs();
+      persistState();
+    });
+
+    addLevelButton.addEventListener("click", () => {
+      const newLevelIndex = levels.length + 1;
+      const level = createLevel(`Level ${newLevelIndex}`);
+      levels.push(level);
+      persistState();
+      updateLevelTabs();
+      setActiveLevel(level.id);
+    });
+
+    duplicateLevelButton.addEventListener("click", () => {
+      const active = getActiveLevel();
+      if (!active) {
+        return;
+      }
+      const clone = {
+        id: uuid(),
+        name: `${active.name} copy`,
+        walls: active.walls.map((wall) => ({
+          start: { ...wall.start },
+          end: { ...wall.end },
+        })),
+        rooms: active.rooms.map((room) => ({ ...room })),
+      };
+      levels.push(clone);
+      persistState();
+      updateLevelTabs();
+      setActiveLevel(clone.id);
+    });
+
+    deleteLevelButton.addEventListener("click", () => {
+      if (levels.length <= 1) {
+        return;
+      }
+      const confirmation = window.confirm(
+        "Delete the current level? This cannot be undone and removes its rooms and walls.",
+      );
+      if (!confirmation) {
+        return;
+      }
+      levels = levels.filter((level) => level.id !== activeLevelId);
+      activeLevelId = levels[0].id;
+      persistState();
+      updateLevelTabs();
+      setActiveLevel(activeLevelId);
+    });
+
+    exportPlanButton.addEventListener("click", () => {
+      const exportData = {
+        schema: "altinet-floorplan",
+        version: 1,
+        exportedAt: new Date().toISOString(),
+        gridSize,
+        unitScale: defaultUnitScale,
+        levels: levels.map((level, index) => ({
+          index,
+          id: level.id,
+          name: level.name,
+          walls: level.walls,
+          rooms: level.rooms,
+        })),
+      };
+      const blob = new Blob([JSON.stringify(exportData, null, 2)], {
+        type: "application/json",
+      });
+      const url = URL.createObjectURL(blob);
+      const link = document.createElement("a");
+      link.href = url;
+      link.download = `altinet-floorplan-${Date.now()}.json`;
+      document.body.appendChild(link);
+      link.click();
+      document.body.removeChild(link);
+      URL.revokeObjectURL(url);
+    });
   })();
 </script>
 {% endblock %}

--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -15,17 +15,20 @@
         <div class="col-lg-5 text-lg-start text-center">
           <h1 class="display-6 fw-semibold mb-3">Welcome home</h1>
           <p class="text-muted mb-4">
-            Explore a 3D overview of your connected home, exported straight from
-            our Blender scene. Rotate, zoom and pan to review every room and
-            device placement.
+            Explore a 3D overview of your connected home, exported directly
+            from the latest Blender build of your floorplan. Rotate, zoom and
+            pan to review every room and device placement.
           </p>
-          <a class="btn btn-primary btn-lg" href="{% url 'admin:index' %}">Open admin</a>
+          <div class="d-grid d-sm-flex gap-2">
+            <a class="btn btn-primary btn-lg" href="{% url 'admin:index' %}">Open admin</a>
+            <a class="btn btn-outline-secondary btn-lg" href="{% url 'web:builder' %}">Edit floorplan</a>
+          </div>
         </div>
         <div class="col-lg-7">
           <div
             id="home-viewer"
             class="viewer-shell rounded-4 border border-2 border-secondary-subtle position-relative overflow-hidden"
-            data-obj-url="{% static 'web/models/home.obj' %}"
+            data-obj-url="{% static home_model_path %}"
           >
             <div class="viewer-overlay d-flex flex-column align-items-center justify-content-center gap-2" data-role="loading">
               <div class="spinner-border text-primary" role="status">
@@ -36,8 +39,8 @@
             <div class="viewer-overlay d-none text-center p-4" data-role="error">
               <h2 class="h5 fw-semibold mb-2">We couldn't load the home</h2>
               <p class="text-muted mb-0">
-                Please refresh the page or check that your browser supports
-                WebGL.
+                Please refresh the page, re-export the floorplan from Blender,
+                or check that your browser supports WebGL.
               </p>
             </div>
             <noscript>

--- a/backend/web/views.py
+++ b/backend/web/views.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
@@ -7,7 +8,13 @@ from django.shortcuts import render
 @login_required
 def home(request):
     """Render the main dashboard once the user is authenticated."""
-    return render(request, "web/home.html")
+    return render(
+        request,
+        "web/home.html",
+        {
+            "home_model_path": getattr(settings, "HOME_MODEL_STATIC_PATH", "web/models/home.obj"),
+        },
+    )
 
 
 @login_required

--- a/docs/workflows/floorplan_pipeline.md
+++ b/docs/workflows/floorplan_pipeline.md
@@ -1,0 +1,52 @@
+# Floorplan to dashboard workflow
+
+This document describes the workflow for taking an interactive floorplan that
+was created in the Altinet web builder and turning it into the 3D model that is
+shown on the authenticated dashboard home page.
+
+## 1. Sketch the plan in the builder
+
+1. Sign in to the web UI and open the **Builder**.
+2. Use the wall and room tools to sketch each storey of the property. The
+   canvas now supports multiple levels – add, duplicate or delete storeys from
+   the header and rename them in the sidebar.
+3. Each level is saved locally in your browser (persisted in `localStorage`).
+   When you're finished, click **Export plan for Blender**. A JSON file will be
+   downloaded with every wall, room and level as well as the grid metadata
+   needed by Blender.
+
+## 2. Generate the 3D model with Blender
+
+1. Copy the exported JSON file into the repository (for example,
+   `assets/floorplans/latest.json`).
+2. From the repository root, run Blender in background mode with the helper
+   script:
+
+   ```bash
+   blender --background --python scripts/generate_floorplan.py -- \
+       --plan assets/floorplans/latest.json \
+       --out assets/floorplans/latest.blend \
+       --obj-out backend/web/static/web/models/home.obj
+   ```
+
+   The script will recreate every level by instancing floor slabs for the rooms
+   and extruded walls for the wall segments. The `--obj-out` option writes an
+   OBJ file in the static assets folder that the dashboard viewer consumes.
+
+## 3. Review the model in the dashboard
+
+1. Reload the authenticated home page. The viewer automatically references the
+   OBJ path defined by the `ALTINET_HOME_MODEL` environment variable (default:
+   `web/models/home.obj`).
+2. Orbit, pan and zoom around the model to verify the geometry matches the
+   exported floorplan. When you iterate on the plan, repeat the export + Blender
+   step to update the OBJ.
+
+## Tips
+
+- The CLI accepts `--storey-height`, `--wall-height` and `--floor-thickness` to
+  tweak proportions per project.
+- If a plan export is missing `unitScale`, pass `--unit-scale` to define how
+  many metres each grid step represents.
+- You can keep multiple OBJ exports and switch between them at runtime by
+  setting `ALTINET_HOME_MODEL=/static/path/to/model.obj` before starting Django.

--- a/scripts/generate_floorplan.py
+++ b/scripts/generate_floorplan.py
@@ -1,12 +1,41 @@
 #!/usr/bin/env python3
-"""Generate a simple 3D floorplan using Blender's Python API."""
+"""Generate a 3D floorplan using Blender's Python API."""
 
 import argparse
+import json
 import math
 import os
 import sys
+from dataclasses import dataclass
+from typing import Iterable, Sequence
 
 import bpy
+
+
+@dataclass
+class Bounds:
+    """Simple container describing 2D bounds in builder space."""
+
+    min_x: float
+    max_x: float
+    min_y: float
+    max_y: float
+
+    @property
+    def width(self) -> float:
+        return self.max_x - self.min_x
+
+    @property
+    def depth(self) -> float:
+        return self.max_y - self.min_y
+
+    @property
+    def centre_x(self) -> float:
+        return (self.min_x + self.max_x) / 2
+
+    @property
+    def centre_y(self) -> float:
+        return (self.min_y + self.max_y) / 2
 
 
 def parse_args():
@@ -17,12 +46,22 @@ def parse_args():
     else:
         argv = []
 
-    parser = argparse.ArgumentParser(description="Generate a simple 3D floorplan.")
-    parser.add_argument("--out", default="assets/floorplans/basic_floorplan.blend", help="Output .blend file path")
-    parser.add_argument("--width", type=float, default=10.0, help="Floor width in meters")
-    parser.add_argument("--depth", type=float, default=8.0, help="Floor depth in meters")
-    parser.add_argument("--wall_height", type=float, default=3.0, help="Wall height in meters")
-    parser.add_argument("--wall_thickness", type=float, default=0.2, help="Wall thickness in meters")
+    parser = argparse.ArgumentParser(description="Generate a 3D floorplan from the Altinet builder export.")
+    parser.add_argument("--out", default="assets/floorplans/generated_floorplan.blend", help="Output .blend file path")
+    parser.add_argument("--plan", help="Path to an exported floorplan JSON from the web builder")
+    parser.add_argument("--obj-out", help="Optional OBJ path for the dashboard viewer")
+    parser.add_argument("--wall-height", type=float, default=3.0, help="Wall height in metres")
+    parser.add_argument("--wall-thickness", type=float, default=0.2, help="Wall thickness in metres")
+    parser.add_argument("--storey-height", type=float, default=3.2, help="Vertical spacing between storeys in metres")
+    parser.add_argument("--floor-thickness", type=float, default=0.15, help="Thickness of each floor slab in metres")
+    parser.add_argument(
+        "--unit-scale",
+        type=float,
+        default=0.5,
+        help="Metres per grid unit if the plan export does not contain unitScale",
+    )
+    parser.add_argument("--fallback-width", type=float, default=10.0, help="Fallback floor width when no plan is provided")
+    parser.add_argument("--fallback-depth", type=float, default=8.0, help="Fallback floor depth when no plan is provided")
     return parser.parse_args(argv)
 
 
@@ -43,46 +82,41 @@ def create_material(name, color):
     return mat
 
 
-def add_floor(width, depth, material):
-    """Add a rectangular floor plane."""
-    bpy.ops.mesh.primitive_plane_add(size=1)
+def add_floor_slab(width, depth, thickness, location, material, name="Floor"):
+    """Add a rectangular floor slab represented as a scaled cube."""
+    bpy.ops.mesh.primitive_cube_add(size=1, location=(location[0], location[1], location[2] - thickness / 2))
     floor = bpy.context.active_object
-    floor.name = "Floor"
-    floor.scale = (width / 2, depth / 2, 1)
+    floor.name = name
+    floor.scale = (width / 2, depth / 2, thickness / 2)
     floor.data.materials.append(material)
     return floor
 
 
-def add_wall(length, thickness, height, location, material):
-    """Add a single wall segment as a scaled cube."""
+def add_wall(length, thickness, height, location, material, rotation=0.0, name="Wall"):
+    """Add a single wall segment as a scaled cube with optional rotation."""
     bpy.ops.mesh.primitive_cube_add(size=1, location=location)
     wall = bpy.context.active_object
-    wall.name = "Wall"
+    wall.name = name
     wall.scale = (length / 2, thickness / 2, height / 2)
+    wall.rotation_euler = (0, 0, rotation)
     wall.data.materials.append(material)
     return wall
 
 
-def add_walls(width, depth, wall_height, wall_thickness, material):
-    """Add four perimeter walls around the floor plane."""
-    z = wall_height / 2
-    d = depth / 2 + wall_thickness / 2
-    w = width / 2 + wall_thickness / 2
-    add_wall(width, wall_thickness, wall_height, (0, d, z), material)   # North
-    add_wall(width, wall_thickness, wall_height, (0, -d, z), material)  # South
-    add_wall(wall_thickness, depth, wall_height, (w, 0, z), material)   # East
-    add_wall(wall_thickness, depth, wall_height, (-w, 0, z), material)  # West
-
-
-def add_camera(width, depth, wall_height):
-    """Create an isometric-style orthographic camera."""
+def add_camera(bounds: Bounds, wall_height: float, storey_height: float):
+    """Create an isometric-style orthographic camera centred on the plan."""
     cam_data = bpy.data.cameras.new("Camera")
     cam_data.type = "ORTHO"
-    cam_data.ortho_scale = max(width, depth) * 1.5
+    radius = max(bounds.width, bounds.depth) * 1.2 / 2
+    cam_data.ortho_scale = max(bounds.width, bounds.depth) * 1.4
 
     cam = bpy.data.objects.new("Camera", cam_data)
     bpy.context.collection.objects.link(cam)
-    cam.location = (width, -depth, wall_height * 2)
+    cam.location = (
+        radius * math.sqrt(2),
+        -radius * math.sqrt(2),
+        wall_height + storey_height,
+    )
     cam.rotation_euler = (math.radians(60), 0, math.radians(45))
     bpy.context.scene.camera = cam
 
@@ -95,6 +129,168 @@ def add_sunlight():
     light.rotation_euler = (math.radians(60), 0, math.radians(45))
 
 
+def load_plan(path: str) -> dict:
+    """Load a builder export JSON."""
+    with open(path, "r", encoding="utf-8") as handle:
+        plan = json.load(handle)
+    if not isinstance(plan, dict) or "levels" not in plan:
+        raise ValueError("Plan export is missing levels")
+    levels = plan["levels"]
+    if not isinstance(levels, Sequence) or len(levels) == 0:
+        raise ValueError("Plan export must contain at least one level")
+    return plan
+
+
+def level_bounds(level: dict, grid_size: float) -> Bounds:
+    """Calculate 2D bounds for a single level."""
+    xs: list[float] = []
+    ys: list[float] = []
+
+    for wall in level.get("walls", []):
+        for key in ("start", "end"):
+            point = wall.get(key)
+            if isinstance(point, dict):
+                xs.append(float(point.get("x", 0)))
+                ys.append(float(point.get("y", 0)))
+    for room in level.get("rooms", []):
+        x = float(room.get("x", 0))
+        y = float(room.get("y", 0))
+        width = float(room.get("width", grid_size))
+        height = float(room.get("height", grid_size))
+        xs.extend([x, x + width])
+        ys.extend([y, y + height])
+
+    if not xs or not ys:
+        return Bounds(0.0, grid_size, 0.0, grid_size)
+
+    return Bounds(min(xs), max(xs), min(ys), max(ys))
+
+
+def aggregate_bounds(levels: Iterable[dict], grid_size: float) -> Bounds:
+    """Combine bounds from multiple levels to determine the overall extents."""
+    all_bounds = [level_bounds(level, grid_size) for level in levels]
+    return Bounds(
+        min(bound.min_x for bound in all_bounds),
+        max(bound.max_x for bound in all_bounds),
+        min(bound.min_y for bound in all_bounds),
+        max(bound.max_y for bound in all_bounds),
+    )
+
+
+def convert_point(point: dict, bounds: Bounds, grid_size: float, unit_scale: float) -> tuple[float, float]:
+    """Convert canvas coordinates to Blender world coordinates."""
+    x = float(point.get("x", 0.0))
+    y = float(point.get("y", 0.0))
+    world_x = ((x - bounds.centre_x) / grid_size) * unit_scale
+    world_y = -((y - bounds.centre_y) / grid_size) * unit_scale
+    return world_x, world_y
+
+
+def build_from_plan(plan: dict, args, floor_mat, wall_mat):
+    """Create geometry in Blender based on the exported plan."""
+    grid_size = float(plan.get("gridSize", 30))
+    unit_scale = float(plan.get("unitScale", args.unit_scale))
+    levels = plan.get("levels", [])
+    plan_bounds = aggregate_bounds(levels, grid_size)
+
+    for index, level in enumerate(levels):
+        level_name = level.get("name") or f"Level {index + 1}"
+        base_height = index * args.storey_height
+
+        for room in level.get("rooms", []):
+            centre_pixel = {
+                "x": room.get("x", 0) + room.get("width", 0) / 2,
+                "y": room.get("y", 0) + room.get("height", 0) / 2,
+            }
+            centre_x, centre_y = convert_point(centre_pixel, plan_bounds, grid_size, unit_scale)
+            width = float(room.get("width", grid_size)) / grid_size * unit_scale
+            depth = float(room.get("height", grid_size)) / grid_size * unit_scale
+            add_floor_slab(
+                width,
+                depth,
+                args.floor_thickness,
+                (centre_x, centre_y, base_height),
+                floor_mat,
+                name=f"{level_name} - {room.get('name', 'Room')} floor",
+            )
+
+        for wall in level.get("walls", []):
+            start = wall.get("start", {})
+            end = wall.get("end", {})
+            start_x, start_y = convert_point(start, plan_bounds, grid_size, unit_scale)
+            end_x, end_y = convert_point(end, plan_bounds, grid_size, unit_scale)
+            length = math.hypot(end_x - start_x, end_y - start_y)
+            if length == 0:
+                continue
+            centre_x = (start_x + end_x) / 2
+            centre_y = (start_y + end_y) / 2
+            rotation = math.atan2(end_y - start_y, end_x - start_x)
+            add_wall(
+                length,
+                args.wall_thickness,
+                args.wall_height,
+                (centre_x, centre_y, base_height + args.wall_height / 2),
+                wall_mat,
+                rotation=rotation,
+                name=f"{level_name} wall",
+            )
+
+    add_camera(plan_bounds, args.wall_height, args.storey_height)
+    add_sunlight()
+
+
+def build_fallback(args, floor_mat, wall_mat):
+    """Fallback geometry when no plan export is provided."""
+    add_floor_slab(
+        args.fallback_width,
+        args.fallback_depth,
+        args.floor_thickness,
+        (0, 0, 0),
+        floor_mat,
+        name="Fallback floor",
+    )
+    add_wall(
+        args.fallback_width,
+        args.wall_thickness,
+        args.wall_height,
+        (0, args.fallback_depth / 2, args.wall_height / 2),
+        wall_mat,
+        name="North wall",
+    )
+    add_wall(
+        args.fallback_width,
+        args.wall_thickness,
+        args.wall_height,
+        (0, -args.fallback_depth / 2, args.wall_height / 2),
+        wall_mat,
+        name="South wall",
+    )
+    add_wall(
+        args.wall_thickness,
+        args.fallback_depth,
+        args.wall_height,
+        (args.fallback_width / 2, 0, args.wall_height / 2),
+        wall_mat,
+        name="East wall",
+    )
+    add_wall(
+        args.wall_thickness,
+        args.fallback_depth,
+        args.wall_height,
+        (-args.fallback_width / 2, 0, args.wall_height / 2),
+        wall_mat,
+        name="West wall",
+    )
+    add_camera(Bounds(-args.fallback_width / 2, args.fallback_width / 2, -args.fallback_depth / 2, args.fallback_depth / 2), args.wall_height, args.storey_height)
+    add_sunlight()
+
+
+def export_obj(path: str):
+    """Export the current scene to OBJ."""
+    bpy.ops.export_scene.obj(filepath=path, use_selection=False, use_materials=False)
+    print(f"OBJ exported to {path}")
+
+
 def main():
     args = parse_args()
 
@@ -102,17 +298,22 @@ def main():
     bpy.context.scene.unit_settings.system = "METRIC"
     bpy.context.scene.unit_settings.scale_length = 1.0
 
-    floor_mat = create_material("FloorMaterial", (0.8, 0.8, 0.8))
-    wall_mat = create_material("WallMaterial", (0.9, 0.9, 0.9))
+    floor_mat = create_material("FloorMaterial", (0.82, 0.82, 0.82))
+    wall_mat = create_material("WallMaterial", (0.92, 0.92, 0.92))
 
-    add_floor(args.width, args.depth, floor_mat)
-    add_walls(args.width, args.depth, args.wall_height, args.wall_thickness, wall_mat)
-    add_camera(args.width, args.depth, args.wall_height)
-    add_sunlight()
+    if args.plan:
+        plan = load_plan(args.plan)
+        build_from_plan(plan, args, floor_mat, wall_mat)
+    else:
+        build_fallback(args, floor_mat, wall_mat)
 
     os.makedirs(os.path.dirname(args.out), exist_ok=True)
     bpy.ops.wm.save_mainfile(filepath=args.out)
     print(f"Floorplan saved to {args.out}")
+
+    if args.obj_out:
+        os.makedirs(os.path.dirname(args.obj_out), exist_ok=True)
+        export_obj(args.obj_out)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add multi-level management, export support, and workflow guidance to the floorplan builder UI
- document the builder → Blender → dashboard pipeline and make the dashboard viewer configurable via settings
- extend the Blender helper script to consume exported plans and generate OBJ files for the home page viewer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d927f5ab28832fb6501f712c58e600