### PR TITLE
Automate builder floorplan sync and OBJ generation

### DIFF
--- a/backend/altinet_backend/settings.py
+++ b/backend/altinet_backend/settings.py
@@ -115,6 +115,31 @@ LOGOUT_REDIRECT_URL = "login"
 # served asset without touching templates.
 HOME_MODEL_STATIC_PATH = os.environ.get("ALTINET_HOME_MODEL", "web/models/home.obj")
 
+# Floorplan automation
+REPO_ROOT = BASE_DIR.parent
+_default_plan_path = REPO_ROOT / "assets" / "floorplans" / "latest.json"
+_default_obj_path = BASE_DIR / "web" / "static" / HOME_MODEL_STATIC_PATH
+FLOORPLAN_PLAN_STORAGE_PATH = Path(
+    os.environ.get("ALTINET_FLOORPLAN_PLAN", str(_default_plan_path))
+)
+FLOORPLAN_OBJ_OUTPUT_PATH = Path(
+    os.environ.get("ALTINET_FLOORPLAN_OBJ", str(_default_obj_path))
+)
+FLOORPLAN_WALL_HEIGHT = float(os.environ.get("ALTINET_FLOORPLAN_WALL_HEIGHT", "3.0"))
+FLOORPLAN_WALL_THICKNESS = float(
+    os.environ.get("ALTINET_FLOORPLAN_WALL_THICKNESS", "0.2")
+)
+FLOORPLAN_STOREY_HEIGHT = float(os.environ.get("ALTINET_FLOORPLAN_STOREY_HEIGHT", "3.2"))
+FLOORPLAN_FLOOR_THICKNESS = float(
+    os.environ.get("ALTINET_FLOORPLAN_FLOOR_THICKNESS", "0.15")
+)
+FLOORPLAN_FALLBACK_WIDTH = float(
+    os.environ.get("ALTINET_FLOORPLAN_FALLBACK_WIDTH", "10.0")
+)
+FLOORPLAN_FALLBACK_DEPTH = float(
+    os.environ.get("ALTINET_FLOORPLAN_FALLBACK_DEPTH", "8.0")
+)
+
 # REST Framework
 REST_FRAMEWORK = {
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",

--- a/backend/spaces/floorplan.py
+++ b/backend/spaces/floorplan.py
@@ -1,0 +1,339 @@
+"""Helpers for generating OBJ meshes from builder floorplans."""
+
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, List, Sequence, Tuple
+
+
+@dataclass
+class Bounds:
+    """Simple container describing 2D bounds in builder space."""
+
+    min_x: float
+    max_x: float
+    min_y: float
+    max_y: float
+
+    @property
+    def width(self) -> float:
+        return self.max_x - self.min_x
+
+    @property
+    def depth(self) -> float:
+        return self.max_y - self.min_y
+
+    @property
+    def centre_x(self) -> float:
+        return (self.min_x + self.max_x) / 2
+
+    @property
+    def centre_y(self) -> float:
+        return (self.min_y + self.max_y) / 2
+
+
+def _level_bounds(level: dict, grid_size: float) -> Bounds:
+    xs: List[float] = []
+    ys: List[float] = []
+
+    for wall in level.get("walls", []):
+        for key in ("start", "end"):
+            point = wall.get(key)
+            if isinstance(point, dict):
+                xs.append(float(point.get("x", 0.0)))
+                ys.append(float(point.get("y", 0.0)))
+
+    for room in level.get("rooms", []):
+        x = float(room.get("x", 0.0))
+        y = float(room.get("y", 0.0))
+        width = float(room.get("width", grid_size))
+        height = float(room.get("height", grid_size))
+        xs.extend([x, x + width])
+        ys.extend([y, y + height])
+
+    if not xs or not ys:
+        return Bounds(0.0, grid_size, 0.0, grid_size)
+
+    return Bounds(min(xs), max(xs), min(ys), max(ys))
+
+
+def _aggregate_bounds(levels: Iterable[dict], grid_size: float) -> Bounds:
+    level_bounds = [_level_bounds(level, grid_size) for level in levels]
+    return Bounds(
+        min(bound.min_x for bound in level_bounds),
+        max(bound.max_x for bound in level_bounds),
+        min(bound.min_y for bound in level_bounds),
+        max(bound.max_y for bound in level_bounds),
+    )
+
+
+def _convert_point(
+    point: dict, bounds: Bounds, grid_size: float, unit_scale: float
+) -> Tuple[float, float]:
+    x = float(point.get("x", 0.0))
+    y = float(point.get("y", 0.0))
+    world_x = ((x - bounds.centre_x) / grid_size) * unit_scale
+    world_y = -((y - bounds.centre_y) / grid_size) * unit_scale
+    return world_x, world_y
+
+
+class FloorplanGenerator:
+    """Generate a lightweight OBJ representation of a builder floorplan."""
+
+    def __init__(
+        self,
+        plan: dict,
+        *,
+        obj_output_path: Path,
+        plan_storage_path: Path | None = None,
+        wall_height: float = 3.0,
+        wall_thickness: float = 0.2,
+        storey_height: float = 3.2,
+        floor_thickness: float = 0.15,
+        fallback_width: float = 10.0,
+        fallback_depth: float = 8.0,
+    ) -> None:
+        self.plan = plan
+        self.obj_output_path = obj_output_path
+        self.plan_storage_path = plan_storage_path
+        self.wall_height = wall_height
+        self.wall_thickness = wall_thickness
+        self.storey_height = storey_height
+        self.floor_thickness = floor_thickness
+        self.fallback_width = fallback_width
+        self.fallback_depth = fallback_depth
+
+    def generate(self) -> dict:
+        """Render the OBJ and persist the canonical plan JSON."""
+
+        levels: Sequence[dict] = self.plan.get("levels", [])
+        if not isinstance(levels, Sequence) or len(levels) == 0:
+            raise ValueError("Floorplan must contain at least one level")
+
+        grid_size = float(self.plan.get("gridSize", 30.0))
+        unit_scale = float(self.plan.get("unitScale", 0.5))
+
+        has_geometry = any(
+            (level.get("rooms") or level.get("walls")) for level in levels
+        )
+
+        vertices: List[Tuple[float, float, float]] = []
+        faces: List[Tuple[int, int, int, int]] = []
+
+        if has_geometry:
+            bounds = _aggregate_bounds(levels, grid_size)
+            room_count = 0
+            wall_count = 0
+            for index, level in enumerate(levels):
+                level_index = int(level.get("index", index))
+                base_height = level_index * self.storey_height
+
+                for room in level.get("rooms", []):
+                    room_count += 1
+                    width_units = float(room.get("width", grid_size)) / grid_size
+                    depth_units = float(room.get("height", grid_size)) / grid_size
+                    width = width_units * unit_scale
+                    depth = depth_units * unit_scale
+                    centre_x = float(room.get("x", 0.0)) + float(
+                        room.get("width", grid_size)
+                    ) / 2
+                    centre_y = float(room.get("y", 0.0)) + float(
+                        room.get("height", grid_size)
+                    ) / 2
+                    world_x, world_y = _convert_point(
+                        {"x": centre_x, "y": centre_y},
+                        bounds,
+                        grid_size,
+                        unit_scale,
+                    )
+                    self._add_aligned_prism(
+                        vertices,
+                        faces,
+                        world_x,
+                        world_y,
+                        width,
+                        depth,
+                        base_height,
+                        max(self.floor_thickness, 0.01),
+                    )
+
+                for wall in level.get("walls", []):
+                    start = wall.get("start", {})
+                    end = wall.get("end", {})
+                    start_pt = _convert_point(start, bounds, grid_size, unit_scale)
+                    end_pt = _convert_point(end, bounds, grid_size, unit_scale)
+                    if start_pt == end_pt:
+                        continue
+                    wall_count += 1
+                    self._add_wall_prism(
+                        vertices,
+                        faces,
+                        start_pt,
+                        end_pt,
+                        base_height,
+                        max(self.wall_height, 0.1),
+                        max(self.wall_thickness, 0.05),
+                    )
+        else:
+            bounds = Bounds(-0.5, 0.5, -0.5, 0.5)
+            room_count = 0
+            wall_count = 0
+            self._add_aligned_prism(
+                vertices,
+                faces,
+                0.0,
+                0.0,
+                self.fallback_width,
+                self.fallback_depth,
+                0.0,
+                max(self.floor_thickness, 0.01),
+            )
+
+        self._write_obj(vertices, faces)
+        if self.plan_storage_path is not None:
+            self.plan_storage_path.parent.mkdir(parents=True, exist_ok=True)
+            with self.plan_storage_path.open("w", encoding="utf-8") as handle:
+                json.dump(self.plan, handle, indent=2, ensure_ascii=False)
+
+        return {
+            "levels": len(levels),
+            "rooms": room_count,
+            "walls": wall_count,
+            "obj_path": str(self.obj_output_path),
+            "plan_path": str(self.plan_storage_path) if self.plan_storage_path else None,
+            "vertices": len(vertices),
+            "faces": len(faces),
+            "bounds": {
+                "width": bounds.width,
+                "depth": bounds.depth,
+            },
+        }
+
+    def _add_aligned_prism(
+        self,
+        vertices: List[Tuple[float, float, float]],
+        faces: List[Tuple[int, int, int, int]],
+        centre_x: float,
+        centre_y: float,
+        width: float,
+        depth: float,
+        base_height: float,
+        height: float,
+    ) -> None:
+        half_w = width / 2
+        half_d = depth / 2
+        corners = [
+            (centre_x - half_w, centre_y - half_d),
+            (centre_x + half_w, centre_y - half_d),
+            (centre_x + half_w, centre_y + half_d),
+            (centre_x - half_w, centre_y + half_d),
+        ]
+        self._add_prism(vertices, faces, corners, base_height, height)
+
+    def _add_wall_prism(
+        self,
+        vertices: List[Tuple[float, float, float]],
+        faces: List[Tuple[int, int, int, int]],
+        start: Tuple[float, float],
+        end: Tuple[float, float],
+        base_height: float,
+        wall_height: float,
+        wall_thickness: float,
+    ) -> None:
+        start_x, start_y = start
+        end_x, end_y = end
+        dx = end_x - start_x
+        dy = end_y - start_y
+        length = math.hypot(dx, dy)
+        if length == 0:
+            return
+        ux = dx / length
+        uy = dy / length
+        px = -uy
+        py = ux
+        half_len = length / 2
+        half_thick = wall_thickness / 2
+        mid_x = (start_x + end_x) / 2
+        mid_y = (start_y + end_y) / 2
+        corners = [
+            (
+                mid_x - ux * half_len - px * half_thick,
+                mid_y - uy * half_len - py * half_thick,
+            ),
+            (
+                mid_x + ux * half_len - px * half_thick,
+                mid_y + uy * half_len - py * half_thick,
+            ),
+            (
+                mid_x + ux * half_len + px * half_thick,
+                mid_y + uy * half_len + py * half_thick,
+            ),
+            (
+                mid_x - ux * half_len + px * half_thick,
+                mid_y - uy * half_len + py * half_thick,
+            ),
+        ]
+        self._add_prism(vertices, faces, corners, base_height, wall_height)
+
+    def _add_prism(
+        self,
+        vertices: List[Tuple[float, float, float]],
+        faces: List[Tuple[int, int, int, int]],
+        base_corners: Sequence[Tuple[float, float]],
+        base_height: float,
+        height: float,
+    ) -> None:
+        start_index = len(vertices) + 1
+        for x, y in base_corners:
+            vertices.append((x, y, base_height))
+        for x, y in base_corners:
+            vertices.append((x, y, base_height + height))
+        faces.extend(
+            [
+                (start_index, start_index + 1, start_index + 2, start_index + 3),
+                (
+                    start_index + 4,
+                    start_index + 5,
+                    start_index + 6,
+                    start_index + 7,
+                ),
+                (
+                    start_index,
+                    start_index + 1,
+                    start_index + 5,
+                    start_index + 4,
+                ),
+                (
+                    start_index + 1,
+                    start_index + 2,
+                    start_index + 6,
+                    start_index + 5,
+                ),
+                (
+                    start_index + 2,
+                    start_index + 3,
+                    start_index + 7,
+                    start_index + 6,
+                ),
+                (
+                    start_index + 3,
+                    start_index,
+                    start_index + 4,
+                    start_index + 7,
+                ),
+            ]
+        )
+
+    def _write_obj(
+        self, vertices: Sequence[Tuple[float, float, float]], faces: Sequence[Tuple[int, int, int, int]]
+    ) -> None:
+        self.obj_output_path.parent.mkdir(parents=True, exist_ok=True)
+        with self.obj_output_path.open("w", encoding="utf-8") as handle:
+            handle.write("# Altinet autogenerated floorplan\n")
+            for x, y, z in vertices:
+                handle.write(f"v {x:.6f} {y:.6f} {z:.6f}\n")
+            for face in faces:
+                handle.write("f " + " ".join(str(index) for index in face) + "\n")

--- a/backend/spaces/serializers.py
+++ b/backend/spaces/serializers.py
@@ -351,3 +351,49 @@ class FaceSnapshotSerializer(serializers.ModelSerializer):
             if embedding:
                 validated_data["embedding"] = embedding
         return super().create(validated_data)
+class FloorplanPointSerializer(serializers.Serializer):
+    x = serializers.FloatField()
+    y = serializers.FloatField()
+
+
+class FloorplanWallSerializer(serializers.Serializer):
+    start = FloorplanPointSerializer()
+    end = FloorplanPointSerializer()
+
+
+class FloorplanRoomExportSerializer(serializers.Serializer):
+    name = serializers.CharField(allow_blank=True, default="")
+    x = serializers.FloatField()
+    y = serializers.FloatField()
+    width = serializers.FloatField()
+    height = serializers.FloatField()
+
+
+class FloorplanLevelSerializer(serializers.Serializer):
+    index = serializers.IntegerField(required=False)
+    id = serializers.CharField(allow_blank=True, required=False)
+    name = serializers.CharField(allow_blank=True, required=False)
+    walls = FloorplanWallSerializer(many=True, required=False)
+    rooms = FloorplanRoomExportSerializer(many=True, required=False)
+
+    def validate_walls(self, value):
+        return value or []
+
+    def validate_rooms(self, value):
+        return value or []
+
+
+class FloorplanUploadSerializer(serializers.Serializer):
+    schema = serializers.CharField(allow_blank=True, required=False)
+    version = serializers.IntegerField(required=False)
+    exportedAt = serializers.DateTimeField(required=False)
+    updatedAt = serializers.DateTimeField(required=False)
+    gridSize = serializers.FloatField(required=False, default=30.0)
+    unitScale = serializers.FloatField(required=False, default=0.5)
+    levels = FloorplanLevelSerializer(many=True)
+
+    def validate_levels(self, value):
+        if not value:
+            raise serializers.ValidationError("At least one level is required")
+        return value
+

--- a/backend/spaces/urls.py
+++ b/backend/spaces/urls.py
@@ -9,6 +9,7 @@ from .views import (
     CameraViewSet,
     FaceEmbeddingViewSet,
     FaceSnapshotViewSet,
+    FloorplanRenderView,
     IdentityViewSet,
     RoomViewSet,
 )
@@ -21,5 +22,6 @@ router.register("face-embeddings", FaceEmbeddingViewSet)
 router.register("face-snapshots", FaceSnapshotViewSet)
 
 urlpatterns = [
+    path("floorplans/render/", FloorplanRenderView.as_view(), name="floorplan-render"),
     path("", include(router.urls)),
 ]

--- a/backend/templates/web/builder.html
+++ b/backend/templates/web/builder.html
@@ -70,8 +70,8 @@
           <h2 class="h6 fw-semibold mb-2">Workflow</h2>
           <ol class="mb-0 small ps-3">
             <li>Sketch each storey of the property using the tools above and switch levels as needed.</li>
-            <li>Export the floorplan once you are happy. The export contains geometry that Blender can read.</li>
-            <li>Open the exported JSON in Blender with <code>scripts/generate_floorplan.py</code> to create the 3D model shown on the dashboard.</li>
+            <li>Your changes sync to the backend automatically, triggering a fresh 3D model build for the dashboard viewer.</li>
+            <li>Use the export button if you still need a JSON copy for external tools or manual Blender tweaks.</li>
           </ol>
         </div>
       </div>
@@ -88,7 +88,7 @@
         <div class="mt-3">
           <button type="button" class="btn btn-primary w-100" id="exportPlan">Export plan for Blender</button>
           <p class="small text-muted mt-2 mb-0">
-            Exports to <code>.json</code> with every wall and room per level. Import it via Blender: <code>blender --python scripts/generate_floorplan.py -- --plan &lt;file&gt; --obj-out assets/home.obj</code>.
+            Need an offline copy? Export to <code>.json</code> for Blender or archiving &mdash; the backend already rebuilds the OBJ automatically.
           </p>
         </div>
       </div>
@@ -103,8 +103,17 @@
     const gridSize = 30;
     const storageKey = "altinet-floorplan";
     const defaultUnitScale = 0.5; // metres per grid unit
+    const syncEndpoint = "/api/floorplans/render/";
+    const syncDelayMs = 1500;
+    let lastUpdatedAt = null;
+    let syncTimeoutId = null;
+    let queuedPayload = null;
+    let queuedHash = null;
+    let inFlight = false;
+    let lastSyncedHash = null;
     let levels = [];
     let activeLevelId = null;
+    let needsInitialPersist = false;
     let isDrawing = false;
     let startPoint = null;
     let previewPoint = null;
@@ -121,6 +130,103 @@
     const deleteLevelButton = document.getElementById("deleteLevel");
     const exportPlanButton = document.getElementById("exportPlan");
     const activeLevelBadge = document.getElementById("activeLevelLabel");
+
+    function getCsrfToken() {
+      const name = "csrftoken=";
+      const cookies = document.cookie ? document.cookie.split(";") : [];
+      for (const cookie of cookies) {
+        const trimmed = cookie.trim();
+        if (trimmed.startsWith(name)) {
+          return decodeURIComponent(trimmed.slice(name.length));
+        }
+      }
+      return "";
+    }
+
+    function buildPlanPayload({ timestamp = null, includeExportMetadata = false } = {}) {
+      const updatedTimestamp = timestamp || lastUpdatedAt || new Date().toISOString();
+      const payload = {
+        schema: "altinet-floorplan",
+        version: 1,
+        updatedAt: updatedTimestamp,
+        gridSize,
+        unitScale: defaultUnitScale,
+        levels: levels.map((level, index) => ({
+          index,
+          id: level.id,
+          name: level.name,
+          walls: level.walls,
+          rooms: level.rooms,
+        })),
+      };
+      if (includeExportMetadata) {
+        payload.exportedAt = new Date().toISOString();
+      }
+      return payload;
+    }
+
+    function resetSyncTimer() {
+      if (syncTimeoutId) {
+        window.clearTimeout(syncTimeoutId);
+      }
+      syncTimeoutId = window.setTimeout(sendQueuedPayload, syncDelayMs);
+    }
+
+    function sendQueuedPayload() {
+      if (!queuedPayload) {
+        return;
+      }
+      const payload = queuedPayload;
+      const payloadHash = queuedHash;
+      queuedPayload = null;
+      queuedHash = null;
+      syncTimeoutId = null;
+      inFlight = true;
+      let succeeded = false;
+      fetch(syncEndpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": getCsrfToken(),
+        },
+        credentials: "same-origin",
+        body: JSON.stringify(payload),
+      })
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error(`Sync failed with status ${response.status}`);
+          }
+          succeeded = true;
+          lastSyncedHash = payloadHash;
+        })
+        .catch((error) => {
+          console.warn("Could not sync floorplan to backend", error);
+        })
+        .finally(() => {
+          inFlight = false;
+          if (!succeeded && !queuedPayload) {
+            queuedPayload = payload;
+            queuedHash = payloadHash;
+          }
+          if (queuedPayload) {
+            resetSyncTimer();
+          }
+        });
+    }
+
+    function scheduleSync(timestamp) {
+      const payload = buildPlanPayload({ timestamp });
+      const serialized = JSON.stringify(payload);
+      if (serialized === lastSyncedHash || serialized === queuedHash) {
+        return;
+      }
+      queuedPayload = JSON.parse(serialized);
+      queuedHash = serialized;
+      if (inFlight) {
+        return;
+      }
+      resetSyncTimer();
+    }
 
     function setActiveTool(tool) {
       activeTool = tool;
@@ -160,6 +266,8 @@
           const initialLevel = createLevel("Level 1");
           levels = [initialLevel];
           activeLevelId = initialLevel.id;
+          lastUpdatedAt = new Date().toISOString();
+          needsInitialPersist = true;
           return;
         }
         const parsed = JSON.parse(stored);
@@ -174,30 +282,40 @@
         }));
         const storedActive = levels.find((level) => level.id === parsed.activeLevelId);
         activeLevelId = storedActive ? storedActive.id : levels[0].id;
+        lastUpdatedAt =
+          typeof parsed.updatedAt === "string" ? parsed.updatedAt : new Date().toISOString();
+        needsInitialPersist = false;
       } catch (error) {
         console.warn("Could not load saved plan, resetting", error);
         const reset = createLevel("Level 1");
         levels = [reset];
         activeLevelId = reset.id;
+        lastUpdatedAt = new Date().toISOString();
+        needsInitialPersist = true;
         localStorage.removeItem(storageKey);
       }
     }
 
     function persistState() {
+      const updatedAt = new Date().toISOString();
+      lastUpdatedAt = updatedAt;
       const payload = {
         version: 1,
-        updatedAt: new Date().toISOString(),
+        updatedAt,
         activeLevelId,
         levels,
       };
       localStorage.setItem(storageKey, JSON.stringify(payload));
+      needsInitialPersist = false;
+      scheduleSync(updatedAt);
     }
 
     function getActiveLevel() {
       return levels.find((level) => level.id === activeLevelId) || null;
     }
 
-    function setActiveLevel(levelId) {
+    function setActiveLevel(levelId, options = {}) {
+      const { persist = true } = options;
       const level = levels.find((item) => item.id === levelId);
       if (!level) {
         return;
@@ -208,7 +326,9 @@
       updateLevelTabs();
       updateRoomList();
       render();
-      persistState();
+      if (persist) {
+        persistState();
+      }
     }
 
     function updateLevelTabs() {
@@ -489,9 +609,15 @@
 
     loadState();
     updateLevelTabs();
-    setActiveLevel(activeLevelId);
+    setActiveLevel(activeLevelId, { persist: false });
     updateRoomList();
     render();
+
+    if (needsInitialPersist) {
+      persistState();
+    } else if (lastUpdatedAt) {
+      scheduleSync(lastUpdatedAt);
+    }
 
     levelNameInput.addEventListener("input", (event) => {
       const level = getActiveLevel();
@@ -552,20 +678,10 @@
     });
 
     exportPlanButton.addEventListener("click", () => {
-      const exportData = {
-        schema: "altinet-floorplan",
-        version: 1,
-        exportedAt: new Date().toISOString(),
-        gridSize,
-        unitScale: defaultUnitScale,
-        levels: levels.map((level, index) => ({
-          index,
-          id: level.id,
-          name: level.name,
-          walls: level.walls,
-          rooms: level.rooms,
-        })),
-      };
+      const exportData = buildPlanPayload({
+        includeExportMetadata: true,
+        timestamp: lastUpdatedAt || new Date().toISOString(),
+      });
       const blob = new Blob([JSON.stringify(exportData, null, 2)], {
         type: "application/json",
       });

--- a/docs/workflows/floorplan_pipeline.md
+++ b/docs/workflows/floorplan_pipeline.md
@@ -15,23 +15,25 @@ shown on the authenticated dashboard home page.
    downloaded with every wall, room and level as well as the grid metadata
    needed by Blender.
 
-## 2. Generate the 3D model with Blender
+## 2. Automatic 3D model generation
 
-1. Copy the exported JSON file into the repository (for example,
-   `assets/floorplans/latest.json`).
-2. From the repository root, run Blender in background mode with the helper
-   script:
+The builder now syncs every change to the Django backend. The API writes the
+latest floorplan JSON to `assets/floorplans/latest.json` and regenerates the
+OBJ served to the dashboard (`backend/web/static/web/models/home.obj`) using a
+lightweight Python renderer. Reload the authenticated home page to see the
+updated geometry moments after saving in the builder.
 
-   ```bash
-   blender --background --python scripts/generate_floorplan.py -- \
-       --plan assets/floorplans/latest.json \
-       --out assets/floorplans/latest.blend \
-       --obj-out backend/web/static/web/models/home.obj
-   ```
+### Optional: manual Blender exports
 
-   The script will recreate every level by instancing floor slabs for the rooms
-   and extruded walls for the wall segments. The `--obj-out` option writes an
-   OBJ file in the static assets folder that the dashboard viewer consumes.
+If you need to iterate with Blender directly, use **Export plan for Blender**
+and follow the original workflow:
+
+```bash
+blender --background --python scripts/generate_floorplan.py -- \
+    --plan assets/floorplans/latest.json \
+    --out assets/floorplans/latest.blend \
+    --obj-out backend/web/static/web/models/home.obj
+```
 
 ## 3. Review the model in the dashboard
 


### PR DESCRIPTION
## Summary
- add configurable floorplan automation settings and an OBJ generator that persists the latest plan and model through a dedicated API endpoint
- extend the builder UI to sync plans back to the backend automatically while updating guidance around the new workflow
- cover the new pipeline with API tests and refresh the floorplan workflow documentation

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d9b8cade40832fa64185279dabd108