### PR TITLE
Rotate home viewer walls onto base plane

### DIFF
--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -231,6 +231,11 @@ function buildMeshGroup(groups, materials) {
     mesh.name = name;
     mesh.castShadow = true;
     mesh.receiveShadow = true;
+
+    if (name.toLowerCase().includes('wall')) {
+      mesh.rotation.x = -Math.PI / 2;
+    }
+
     root.add(mesh);
   }
 


### PR DESCRIPTION
## Summary
- rotate wall meshes within the home viewer so they lie flat against the base plane when rendered

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c56ec3ec832f823c56e03107b00b