### PR TITLE
Gracefully handle missing SystemSettings table

### DIFF
--- a/backend/web/tests/test_models.py
+++ b/backend/web/tests/test_models.py
@@ -1,0 +1,15 @@
+import pytest
+from django.db import connection
+
+from web.models import SystemSettings
+
+
+@pytest.mark.django_db
+def test_load_returns_defaults_when_table_missing(monkeypatch):
+    monkeypatch.setattr(connection.introspection, "table_names", lambda: [])
+
+    settings = SystemSettings.load()
+
+    assert settings.pk is None
+    assert settings.site_name == "Altinet"
+    assert settings.maintenance_mode is False


### PR DESCRIPTION
## Summary
- guard `SystemSettings.load()` so the settings page works even before migrations
- return default settings when the database table is absent instead of raising
- add a regression test covering the missing-table fallback

## Testing
- pytest backend/web/tests/test_models.py

------
https://chatgpt.com/codex/tasks/task_e_68d9e246d12c832fbbbdecd44411ae5e