### PR TITLE
Make home viewer walls semi-transparent

### DIFF
--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -60,6 +60,8 @@ function initialiseViewer(containerEl, objUrl) {
     color: 0xd4dae4,
     roughness: 0.6,
     metalness: 0.05,
+    transparent: true,
+    opacity: 0.5,
   });
 
   const roofMaterial = new THREE.MeshStandardMaterial({


### PR DESCRIPTION
## Summary
- make the home viewer's wall material semi-transparent so walls render at 50% opacity

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9e8e9a9e0832fad90450375a5e226