### PR TITLE
Remove circular ground plane from home viewer

### DIFF
--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -49,13 +49,6 @@ function initialiseViewer(containerEl, objUrl) {
 
   scene.add(ambientLight, keyLight, fillLight);
 
-  const groundGeometry = new THREE.CircleGeometry(6, 64);
-  const groundMaterial = new THREE.MeshStandardMaterial({ color: 0xdfe6f3 });
-  const ground = new THREE.Mesh(groundGeometry, groundMaterial);
-  ground.rotation.x = -Math.PI / 2;
-  ground.position.y = -0.001;
-  scene.add(ground);
-
   const wallMaterial = new THREE.MeshStandardMaterial({
     color: 0xd4dae4,
     roughness: 0.6,


### PR DESCRIPTION
## Summary
- remove the circular ground mesh from the home viewer scene to eliminate the distracting disk beneath the model

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d9ed518bec832f9caf8fbc1984d5f5