### PR TITLE
Expand home viewer prominence on dashboard

### DIFF
--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -11,20 +11,8 @@
 <div class="row justify-content-center">
   <div class="col-12 col-xl-10">
     <div class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5 mb-4">
-      <div class="row gy-4 align-items-center">
-        <div class="col-lg-5 text-lg-start text-center">
-          <h1 class="display-6 fw-semibold mb-3">Welcome home</h1>
-          <p class="text-muted mb-4">
-            Explore a 3D overview of your connected home, exported directly
-            from the latest Blender build of your floorplan. Rotate, zoom and
-            pan to review every room and device placement.
-          </p>
-          <div class="d-grid d-sm-flex gap-2">
-            <a class="btn btn-primary btn-lg" href="{% url 'admin:index' %}">Open admin</a>
-            <a class="btn btn-outline-secondary btn-lg" href="{% url 'web:builder' %}">Edit floorplan</a>
-          </div>
-        </div>
-        <div class="col-lg-7">
+      <div class="row gy-4 align-items-center flex-lg-row-reverse">
+        <div class="col-12 col-lg-8 col-xl-9">
           <div
             id="home-viewer"
             class="viewer-shell rounded-4 border border-2 border-secondary-subtle position-relative overflow-hidden"
@@ -51,6 +39,18 @@
                 </p>
               </div>
             </noscript>
+          </div>
+        </div>
+        <div class="col-12 col-lg-4 col-xl-3 text-lg-start text-center">
+          <h1 class="display-5 fw-semibold mb-3">Welcome home</h1>
+          <p class="text-muted mb-4">
+            Explore a 3D overview of your connected home, exported directly
+            from the latest Blender build of your floorplan. Rotate, zoom and
+            pan to review every room and device placement.
+          </p>
+          <div class="d-grid d-sm-flex gap-2 justify-content-center justify-content-lg-start">
+            <a class="btn btn-primary btn-lg" href="{% url 'admin:index' %}">Open admin</a>
+            <a class="btn btn-outline-secondary btn-lg" href="{% url 'web:builder' %}">Edit floorplan</a>
           </div>
         </div>
       </div>

--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -1,5 +1,5 @@
 #home-viewer {
-  min-height: 60vh;
+  min-height: 80vh;
   background: linear-gradient(180deg, #f8f9fb 0%, #e9eef5 100%);
 }
 


### PR DESCRIPTION
## Summary
- widen the home page layout so the 3D viewer occupies most of the available width
- increase the viewer container height to emphasize the model on initial load

## Testing
- python backend/manage.py runserver 0.0.0.0:8000

------
https://chatgpt.com/codex/tasks/task_e_68d9fbfac7e4832f8123e7634c2d752e