### PR TITLE
Add live data panel to home dashboard

### DIFF
--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -57,6 +57,33 @@
     </div>
   </div>
 </div>
+<div class="row justify-content-center">
+  <div class="col-12 col-xl-10">
+    <section class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5">
+      <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-4">
+        <div>
+          <h2 class="h4 fw-semibold mb-2">Live home snapshot</h2>
+          <p class="text-muted mb-0">Stay on top of the latest sensor readings and conditions.</p>
+        </div>
+        <div class="text-muted small d-flex align-items-center gap-2">
+          <span class="status-indicator bg-success-subtle border border-success-subtle"></span>
+          <span>Updated {{ environment_snapshot.local_time|date:"g:i A" }} local</span>
+        </div>
+      </div>
+      <div class="row g-3 g-md-4">
+        {% for metric in dashboard_metrics %}
+        <div class="col-12 col-sm-6 col-lg-4 col-xxl-3">
+          <div class="metric-card h-100 border border-2 border-secondary-subtle rounded-4 p-3 p-xl-4">
+            <p class="text-uppercase text-muted small fw-semibold mb-2">{{ metric.label }}</p>
+            <p class="display-6 fs-2 fw-semibold mb-1">{{ metric.value }}</p>
+            <p class="text-muted small mb-0">{{ metric.detail }}</p>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+    </section>
+  </div>
+</div>
 {% endblock %}
 
 {% block extra_scripts %}

--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -18,3 +18,21 @@
   inset: 0;
   background: rgba(255, 255, 255, 0.85);
 }
+
+.metric-card {
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  background-color: #fdfdff;
+}
+
+.metric-card:hover,
+.metric-card:focus-within {
+  transform: translateY(-2px);
+  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
+}
+
+.status-indicator {
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 999px;
+  box-shadow: 0 0 0 1px rgba(25, 135, 84, 0.4);
+}


### PR DESCRIPTION
## Summary
- add a live data snapshot context to the home dashboard with key environmental metrics
- render a new metrics panel on the dashboard and style it for clarity

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68da04941268832fb03c6ea260a84e24