### PR TITLE
Add offline LLaMA service endpoint

### DIFF
--- a/backend/altinet_backend/settings.py
+++ b/backend/altinet_backend/settings.py
@@ -33,6 +33,7 @@ INSTALLED_APPS = [
     "django_filters",
     "drf_spectacular",
     "channels",
+    "llm",
     "spaces",
     "web",
 ]
@@ -180,3 +181,18 @@ FERNET_DERIVED_KEY = derive_fernet_key(FERNET_SECRET)
 # ROS bridge endpoints
 ROS_BRIDGE_BASE_URL = os.environ.get("ROS_BRIDGE_URL", "http://localhost:8001")
 ROS_BRIDGE_WS_URL = os.environ.get("ROS_BRIDGE_WS_URL", "ws://localhost:8001")
+
+# Offline LLaMA configuration
+LLAMA_MODEL_PATH = os.environ.get("ALTINET_LLAMA_MODEL_PATH", "")
+LLAMA_CONTEXT_WINDOW = int(os.environ.get("ALTINET_LLAMA_CONTEXT", "2048"))
+LLAMA_MAX_TOKENS = int(os.environ.get("ALTINET_LLAMA_MAX_TOKENS", "256"))
+LLAMA_TEMPERATURE = float(os.environ.get("ALTINET_LLAMA_TEMPERATURE", "0.7"))
+_llama_stop_sequences = os.environ.get("ALTINET_LLAMA_STOP_SEQUENCES", "")
+if _llama_stop_sequences:
+    LLAMA_STOP_SEQUENCES = tuple(
+        sequence.strip()
+        for sequence in _llama_stop_sequences.split("|")
+        if sequence.strip()
+    )
+else:
+    LLAMA_STOP_SEQUENCES: tuple[str, ...] = tuple()

--- a/backend/altinet_backend/urls.py
+++ b/backend/altinet_backend/urls.py
@@ -16,5 +16,6 @@ urlpatterns = [
         SpectacularSwaggerView.as_view(url_name="schema"),
         name="api-docs",
     ),
+    path("api/llm/", include("llm.urls")),
     path("api/", include("spaces.urls")),
 ]

--- a/backend/llm/__init__.py
+++ b/backend/llm/__init__.py
@@ -1,0 +1,3 @@
+"""Offline LLaMA integration for Altinet."""
+
+__all__ = ["apps"]

--- a/backend/llm/apps.py
+++ b/backend/llm/apps.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from django.apps import AppConfig
+
+
+class LlmConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "llm"
+    verbose_name = "Language Model"

--- a/backend/llm/serializers.py
+++ b/backend/llm/serializers.py
@@ -1,0 +1,15 @@
+"""Serializers for LLaMA endpoints."""
+
+from __future__ import annotations
+
+from rest_framework import serializers
+
+
+class PromptRequestSerializer(serializers.Serializer):
+    prompt = serializers.CharField(max_length=4096, allow_blank=False)
+    max_tokens = serializers.IntegerField(min_value=1, max_value=4096, required=False)
+    temperature = serializers.FloatField(min_value=0.0, max_value=2.0, required=False)
+
+
+class PromptResponseSerializer(serializers.Serializer):
+    response = serializers.CharField()

--- a/backend/llm/services.py
+++ b/backend/llm/services.py
@@ -1,0 +1,105 @@
+"""Services for interacting with an offline LLaMA model."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Iterable, Optional, Sequence
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+try:  # pragma: no cover - optional dependency
+    from llama_cpp import Llama  # type: ignore
+except ImportError:  # pragma: no cover - optional dependency
+    Llama = None  # type: ignore
+
+
+@dataclass
+class OfflineLlamaConfig:
+    """Configuration for the offline LLaMA model."""
+
+    model_path: str
+    context_window: int
+    temperature: float
+    stop_sequences: Sequence[str]
+
+
+class OfflineLlama:
+    """Thin wrapper around :class:`llama_cpp.Llama` with sane defaults."""
+
+    def __init__(
+        self,
+        config: OfflineLlamaConfig,
+        backend: Optional["Llama"] = None,
+    ) -> None:
+        if backend is None:
+            if Llama is None:
+                raise ImproperlyConfigured(
+                    "llama-cpp-python is not installed. Add it to requirements to use the offline model.",
+                )
+            if not os.path.exists(config.model_path):
+                raise ImproperlyConfigured(
+                    f"LLaMA model path '{config.model_path}' does not exist."
+                )
+            backend = Llama(
+                model_path=config.model_path,
+                n_ctx=config.context_window,
+                logits_all=False,
+            )
+
+        self._backend = backend
+        self._temperature = config.temperature
+        self._stop_sequences = list(config.stop_sequences)
+
+    def generate(
+        self,
+        prompt: str,
+        *,
+        max_tokens: Optional[int] = None,
+        temperature: Optional[float] = None,
+        stop_sequences: Optional[Iterable[str]] = None,
+    ) -> str:
+        """Generate a completion for ``prompt`` and return the raw text."""
+
+        kwargs = {
+            "max_tokens": max_tokens or settings.LLAMA_MAX_TOKENS,
+            "temperature": temperature if temperature is not None else self._temperature,
+        }
+        stops = list(stop_sequences) if stop_sequences is not None else self._stop_sequences
+        if stops:
+            kwargs["stop"] = stops
+
+        completion = self._backend(
+            prompt,
+            **kwargs,
+        )
+        choice = completion["choices"][0]
+        text = choice.get("text") or choice.get("message", {}).get("content", "")
+        return text.strip()
+
+
+def _build_config() -> OfflineLlamaConfig:
+    if not settings.LLAMA_MODEL_PATH:
+        raise ImproperlyConfigured("LLAMA_MODEL_PATH is not configured")
+
+    return OfflineLlamaConfig(
+        model_path=settings.LLAMA_MODEL_PATH,
+        context_window=settings.LLAMA_CONTEXT_WINDOW,
+        temperature=settings.LLAMA_TEMPERATURE,
+        stop_sequences=settings.LLAMA_STOP_SEQUENCES,
+    )
+
+
+@lru_cache(maxsize=1)
+def get_default_llama() -> OfflineLlama:
+    """Return a shared :class:`OfflineLlama` instance for the service."""
+
+    return OfflineLlama(_build_config())
+
+
+def reset_llama_cache() -> None:
+    """Reset the cached LLaMA instance (useful for tests)."""
+
+    get_default_llama.cache_clear()

--- a/backend/llm/tests/test_views.py
+++ b/backend/llm/tests/test_views.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import pytest
+from django.core.exceptions import ImproperlyConfigured
+from django.urls import reverse
+
+from llm.services import reset_llama_cache
+
+
+@pytest.fixture(autouse=True)
+def clear_llama_cache():
+    reset_llama_cache()
+    yield
+    reset_llama_cache()
+
+
+@pytest.fixture
+def prompt_url() -> str:
+    return reverse("llm:prompt")
+
+
+@pytest.fixture
+def health_url() -> str:
+    return reverse("llm:health")
+
+
+class DummyLlama:
+    def __init__(self):
+        self.prompts: list[str] = []
+
+    def generate(self, prompt: str, **kwargs):
+        self.prompts.append(prompt)
+        temperature = kwargs.get("temperature")
+        token_info = kwargs.get("max_tokens")
+        return f"prompt={prompt};temp={temperature};tokens={token_info}"
+
+
+@pytest.fixture
+def dummy_llama(monkeypatch):
+    llama = DummyLlama()
+    monkeypatch.setattr("llm.views.get_default_llama", lambda: llama)
+    return llama
+
+
+@pytest.mark.django_db
+def test_prompt_endpoint_returns_response(client, prompt_url, dummy_llama):
+    payload = {"prompt": "Hello", "temperature": 0.5, "max_tokens": 128}
+    response = client.post(prompt_url, payload, content_type="application/json")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["response"] == "prompt=Hello;temp=0.5;tokens=128"
+    assert dummy_llama.prompts == ["Hello"]
+
+
+@pytest.mark.django_db
+def test_prompt_endpoint_requires_prompt(client, prompt_url):
+    response = client.post(prompt_url, {}, content_type="application/json")
+
+    assert response.status_code == 400
+    assert "prompt" in response.json()
+
+
+@pytest.mark.django_db
+def test_prompt_endpoint_returns_service_unavailable_when_unconfigured(
+    client, prompt_url, monkeypatch
+):
+    def raise_config_error():
+        raise ImproperlyConfigured("missing model")
+
+    monkeypatch.setattr("llm.views.get_default_llama", raise_config_error)
+
+    response = client.post(prompt_url, {"prompt": "Hello"}, content_type="application/json")
+
+    assert response.status_code == 503
+    payload = response.json()
+    assert payload["detail"] == "missing model"
+
+
+@pytest.mark.django_db
+def test_health_endpoint_ok(client, health_url, dummy_llama):
+    response = client.get(health_url)
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+@pytest.mark.django_db
+def test_health_endpoint_reports_error(client, health_url, monkeypatch):
+    def raise_config_error():
+        raise ImproperlyConfigured("missing model")
+
+    monkeypatch.setattr("llm.views.get_default_llama", raise_config_error)
+
+    response = client.get(health_url)
+
+    assert response.status_code == 503
+    assert response.json() == {"status": "error", "detail": "missing model"}

--- a/backend/llm/urls.py
+++ b/backend/llm/urls.py
@@ -1,0 +1,14 @@
+"""URL routing for the LLaMA app."""
+
+from __future__ import annotations
+
+from django.urls import path
+
+from .views import HealthView, LlamaPromptView
+
+app_name = "llm"
+
+urlpatterns = [
+    path("prompt/", LlamaPromptView.as_view(), name="prompt"),
+    path("health/", HealthView.as_view(), name="health"),
+]

--- a/backend/llm/views.py
+++ b/backend/llm/views.py
@@ -1,0 +1,61 @@
+"""API views for the offline LLaMA model."""
+
+from __future__ import annotations
+
+from django.core.exceptions import ImproperlyConfigured
+from rest_framework import permissions, status
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from .serializers import PromptRequestSerializer, PromptResponseSerializer
+from .services import get_default_llama
+
+
+class LlamaPromptView(APIView):
+    """Accept a prompt and return the generated response."""
+
+    permission_classes = [permissions.AllowAny]
+
+    def post(self, request: Request) -> Response:
+        serializer = PromptRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        try:
+            llama = self._get_llama()
+        except ImproperlyConfigured as exc:
+            return Response(
+                {"detail": str(exc)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        prompt = serializer.validated_data["prompt"]
+        max_tokens = serializer.validated_data.get("max_tokens")
+        temperature = serializer.validated_data.get("temperature")
+
+        response_text = llama.generate(
+            prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+
+        response_serializer = PromptResponseSerializer({"response": response_text})
+        return Response(response_serializer.data, status=status.HTTP_200_OK)
+
+    def _get_llama(self):
+        return get_default_llama()
+
+
+class HealthView(APIView):
+    """Simple health endpoint for readiness checks."""
+
+    permission_classes = [permissions.AllowAny]
+
+    def get(self, request: Request) -> Response:
+        try:
+            get_default_llama()
+        except ImproperlyConfigured as exc:
+            return Response(
+                {"status": "error", "detail": str(exc)},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
+        return Response({"status": "ok"}, status=status.HTTP_200_OK)

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ asgiref>=3.7
 httpx>=0.25
 cryptography>=41.0
 psycopg2-binary>=2.9
+llama-cpp-python>=0.2.0
 pytest>=7.4
 pytest-django>=4.5
 pytest-asyncio>=0.21


### PR DESCRIPTION
## Summary
- add a dedicated llm Django app that exposes prompt and health endpoints for an offline LLaMA model
- configure reusable OfflineLlama service tied to new settings and requirements
- cover the API with request validation and service availability tests

## Testing
- pytest backend/llm/tests/test_views.py

------
https://chatgpt.com/codex/tasks/task_e_68da0cb180e8832f98b1dbdc79680d69