### PR TITLE
Add assistant prompt container to home page

### DIFF
--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -84,8 +84,48 @@
     </section>
   </div>
 </div>
+<div class="row justify-content-center mt-4">
+  <div class="col-12 col-xl-10">
+    <section class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5">
+      <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-4">
+        <div>
+          <h2 class="h4 fw-semibold mb-2">Ask the Altinet assistant</h2>
+          <p class="text-muted mb-0">Summarize readings, plan automations, or get quick insights.</p>
+        </div>
+      </div>
+      <form class="mb-4" data-llm-form>
+        <div class="mb-3">
+          <label class="form-label" for="llmPromptInput">Describe what you need</label>
+          <textarea
+            id="llmPromptInput"
+            class="form-control"
+            rows="4"
+            placeholder="Explain the current weather outlook or draft a new automation trigger..."
+            required
+            data-llm-input
+          ></textarea>
+        </div>
+        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-3">
+          <button type="submit" class="btn btn-primary" data-llm-submit>Send to assistant</button>
+          <div class="text-muted small" data-llm-status aria-live="polite"></div>
+        </div>
+      </form>
+      <div>
+        <h3 class="h5 fw-semibold mb-2">Assistant response</h3>
+        <div
+          class="bg-light border border-secondary-subtle rounded-3 p-3"
+          data-llm-response
+          aria-live="polite"
+        >
+          Responses will appear here once you submit a prompt.
+        </div>
+      </div>
+    </section>
+  </div>
+</div>
 {% endblock %}
 
 {% block extra_scripts %}
 <script type="module" src="{% static 'web/js/home-viewer.js' %}"></script>
+<script type="module" src="{% static 'web/js/home-llm.js' %}"></script>
 {% endblock %}

--- a/backend/web/static/web/js/home-llm.js
+++ b/backend/web/static/web/js/home-llm.js
@@ -1,0 +1,80 @@
+function getCookie(name) {
+  const cookieString = document.cookie;
+  if (!cookieString) {
+    return null;
+  }
+
+  return cookieString
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .filter((cookie) => cookie.startsWith(`${name}=`))
+    .map((cookie) => decodeURIComponent(cookie.substring(name.length + 1)))[0] ?? null;
+}
+
+function setStatus(statusElement, message, isError = false) {
+  if (!statusElement) {
+    return;
+  }
+
+  statusElement.textContent = message;
+  statusElement.classList.toggle("text-danger", isError);
+  statusElement.classList.toggle("text-muted", !isError);
+}
+
+function initializeLlmForm() {
+  const form = document.querySelector("[data-llm-form]");
+  if (!form) {
+    return;
+  }
+
+  const input = form.querySelector("[data-llm-input]");
+  const submitButton = form.querySelector("[data-llm-submit]");
+  const statusElement = form.querySelector("[data-llm-status]");
+  const responseElement = form.parentElement.querySelector("[data-llm-response]");
+
+  form.addEventListener("submit", async (event) => {
+    event.preventDefault();
+    const prompt = input?.value.trim();
+    if (!prompt) {
+      setStatus(statusElement, "Enter a prompt to ask the assistant.", true);
+      input?.focus();
+      return;
+    }
+
+    setStatus(statusElement, "Generating response…");
+    submitButton.disabled = true;
+    submitButton.textContent = "Sending…";
+
+    try {
+      const response = await fetch("/api/llm/prompt/", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-CSRFToken": getCookie("csrftoken") ?? "",
+        },
+        body: JSON.stringify({ prompt }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Assistant returned ${response.status}`);
+      }
+
+      const data = await response.json();
+      const assistantResponse = data.response?.trim();
+      if (assistantResponse) {
+        responseElement.textContent = assistantResponse;
+      } else {
+        responseElement.textContent = "The assistant did not return any content.";
+      }
+      setStatus(statusElement, "Response ready.");
+    } catch (error) {
+      console.error("Failed to fetch assistant response", error);
+      setStatus(statusElement, "We couldn't reach the assistant. Please try again.", true);
+    } finally {
+      submitButton.disabled = false;
+      submitButton.textContent = "Send to assistant";
+    }
+  });
+}
+
+document.addEventListener("DOMContentLoaded", initializeLlmForm);


### PR DESCRIPTION
## Summary
- add an assistant panel beneath the dashboard metrics to capture user prompts
- implement frontend logic that posts prompts to the LLM API and renders the assistant response

## Testing
- pytest backend/llm/tests/test_views.py

------
https://chatgpt.com/codex/tasks/task_e_68da0e8cdd0c832fb26595b78b4999c5