### PR TITLE
Expand dashboard layout to full width

### DIFF
--- a/backend/templates/web/base.html
+++ b/backend/templates/web/base.html
@@ -67,7 +67,7 @@
       </div>
     </nav>
 
-    <main class="container my-5">
+    <main class="container-fluid px-3 px-lg-4 my-5">
       {% if messages %}
       <div class="mb-4">
         {% for message in messages %}

--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -8,8 +8,8 @@
 {% endblock %}
 
 {% block content %}
-<div class="row justify-content-center">
-  <div class="col-12 col-xl-10">
+<div class="row g-4">
+  <div class="col-12">
     <div class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5 mb-4">
       <div class="row gy-4 align-items-center flex-lg-row-reverse">
         <div class="col-12 col-lg-8 col-xl-9">
@@ -68,8 +68,8 @@
     </div>
   </div>
 </div>
-<div class="row justify-content-center mt-4">
-  <div class="col-12 col-xl-10">
+<div class="row mt-4">
+  <div class="col-12">
     <section class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5">
       <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-4">
         <div>


### PR DESCRIPTION
## Summary
- switch the base layout container to a fluid variant so dashboard content can stretch across the viewport
- update the home dashboard rows to span the full width rather than centering within a constrained column

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db0d03d68c832fa1b3024ca0cc39da