### PR TITLE
Adjust hero viewer spacing and snapshot metrics layout

### DIFF
--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -14,18 +14,18 @@
 }
 
 .hero-card .viewer-shell {
-  margin-top: -1.25rem;
+  margin-top: -2rem;
 }
 
 @media (min-width: 768px) {
   .hero-card .viewer-shell {
-    margin-top: -2.5rem;
+    margin-top: -3rem;
   }
 }
 
 @media (min-width: 1200px) {
   .hero-card .viewer-shell {
-    margin-top: -3rem;
+    margin-top: -4.25rem;
   }
 }
 
@@ -65,11 +65,18 @@
   flex-grow: 1;
   overflow-y: auto;
   padding-right: 0.25rem;
+  grid-template-columns: minmax(0, 1fr);
 }
 
 @media (max-width: 991.98px) {
   .snapshot-panel [data-role="metrics"] {
     max-height: none;
     overflow: visible;
+  }
+}
+
+@media (min-width: 576px) {
+  .snapshot-panel [data-role="metrics"] {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }


### PR DESCRIPTION
## Summary
- raise the 3D home viewer so its top aligns with the live snapshot card
- update the snapshot metrics grid to support two-column display when space allows

## Testing
- not run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68db317942cc832f892a5d770d0c5c5d