### PR TITLE
Fix home viewer target clamping

### DIFF
--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -112,8 +112,18 @@ function prepareModel(model, scene, controls) {
 
   scene.add(model);
 
-  controls.target.set(0, size.y * 0.45, 0);
+  const desiredTargetY = size.y * 0.45;
   const camera = controls.object;
+  const epsilon = 0.05;
+  const maxTargetY = camera.position.y - epsilon;
+
+  if (desiredTargetY > maxTargetY) {
+    const delta = desiredTargetY - maxTargetY;
+    camera.position.y += delta;
+  }
+
+  const targetY = Math.min(desiredTargetY, camera.position.y - epsilon);
+  controls.target.set(0, targetY, 0);
   const currentDistance = camera.position.distanceTo(controls.target);
 
   const margin = Math.max(radius * 0.05, 0.25);


### PR DESCRIPTION
## Summary
- clamp the home viewer target height to stay below the camera
- raise the camera when needed so the desired target height remains usable

## Testing
- Not run (dependency installation blocked by proxy restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68db3993c590832fbaf0390a9bdcbf15