### PR TITLE
Revert recent dashboard layout adjustments

### DIFF
--- a/backend/templates/web/base.html
+++ b/backend/templates/web/base.html
@@ -67,7 +67,7 @@
       </div>
     </nav>
 
-    <main class="container-fluid px-3 px-lg-4 my-5">
+    <main class="container my-5">
       {% if messages %}
       <div class="mb-4">
         {% for message in messages %}

--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -8,9 +8,9 @@
 {% endblock %}
 
 {% block content %}
-<div class="row g-4">
-  <div class="col-12">
-    <div class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5 mb-4 hero-card">
+<div class="row justify-content-center">
+  <div class="col-12 col-xl-10">
+    <div class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5 mb-4">
       <div class="row gy-4 align-items-center flex-lg-row-reverse">
         <div class="col-12 col-lg-8 col-xl-9">
           <div
@@ -68,8 +68,8 @@
     </div>
   </div>
 </div>
-<div class="row mt-4">
-  <div class="col-12">
+<div class="row justify-content-center mt-4">
+  <div class="col-12 col-xl-10">
     <section class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5">
       <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-4">
         <div>

--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -9,34 +9,14 @@
   height: 100% !important;
 }
 
-.hero-card {
-  position: relative;
-}
-
-.hero-card .viewer-shell {
-  margin-top: -2rem;
-}
-
-@media (min-width: 768px) {
-  .hero-card .viewer-shell {
-    margin-top: -3rem;
-  }
-}
-
-@media (min-width: 1200px) {
-  .hero-card .viewer-shell {
-    margin-top: -4.25rem;
-  }
+.viewer-shell {
+  border-style: solid;
 }
 
 .viewer-overlay {
   position: absolute;
   inset: 0;
   background: rgba(255, 255, 255, 0.85);
-}
-
-.viewer-shell {
-  border-style: solid;
 }
 
 .metric-card {
@@ -65,18 +45,11 @@
   flex-grow: 1;
   overflow-y: auto;
   padding-right: 0.25rem;
-  grid-template-columns: minmax(0, 1fr);
 }
 
 @media (max-width: 991.98px) {
   .snapshot-panel [data-role="metrics"] {
     max-height: none;
     overflow: visible;
-  }
-}
-
-@media (min-width: 576px) {
-  .snapshot-panel [data-role="metrics"] {
-    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 }

--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -103,47 +103,13 @@ function prepareModel(model, scene, controls) {
   box.getCenter(target);
   const size = new THREE.Vector3();
   box.getSize(size);
-  const boundingSphere = box.getBoundingSphere(new THREE.Sphere());
-  const radius =
-    boundingSphere?.radius || Math.max(size.x, size.y, size.z) * 0.5 || 1;
 
   model.position.sub(target);
   model.position.y -= box.min.y;
 
   scene.add(model);
 
-  const desiredTargetY = size.y * 0.45;
-  const camera = controls.object;
-  const epsilon = 0.05;
-  const maxTargetY = camera.position.y - epsilon;
-
-  if (desiredTargetY > maxTargetY) {
-    const delta = desiredTargetY - maxTargetY;
-    camera.position.y += delta;
-  }
-
-  const targetY = Math.min(desiredTargetY, camera.position.y - epsilon);
-  controls.target.set(0, targetY, 0);
-  const currentDistance = camera.position.distanceTo(controls.target);
-
-  const margin = Math.max(radius * 0.05, 0.25);
-  let minDistance = Math.max(radius + margin, 0.5);
-  let maxDistance = Math.max(radius * 4 + margin, minDistance + margin);
-
-  if (currentDistance > maxDistance) {
-    maxDistance = currentDistance + margin;
-  }
-
-  if (currentDistance < minDistance) {
-    const direction = new THREE.Vector3()
-      .subVectors(camera.position, controls.target)
-      .normalize();
-    const safeDistance = minDistance;
-    camera.position.copy(direction.multiplyScalar(safeDistance).add(controls.target));
-  }
-
-  controls.minDistance = minDistance;
-  controls.maxDistance = Math.max(maxDistance, minDistance + margin);
+  controls.target.set(0, size.y * 0.45, 0);
   controls.update();
 }
 


### PR DESCRIPTION
## Summary
- revert merges #143 through #148 to restore the dashboard before the width-related changes
- re-center the dashboard containers and remove recent camera logic tweaks to match the previous layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db3b35ef44832f9d1a0313a4cf0f60