### PR TITLE
Revert pull requests #141 and #142

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,40 +133,6 @@ assistant locally:
    The home dashboard ships with a basic form that posts to the same endpoint
    (`/` → *Assistant* card) so operators can experiment without leaving the UI.
 
-
-### Query the assistant from ROS 2
-
-The ROS 2 workspace also exposes the assistant through a synchronous service so
-nodes can obtain completions without touching HTTP clients directly. After
-building and sourcing `ros2_ws`, launch the bridge that proxies calls to the
-Django backend:
-
-```bash
-ros2 run altinet llm_service_node \
-  --ros-args \
-  -p api_base:=http://127.0.0.1:8000/api/llm \
-  -p default_max_tokens:=256 \
-  -p default_temperature:=0.7
-```
-
-Once the node is running you should see `/altinet/llm/prompt` listed under
-`ros2 service list`. Invoke it from any terminal to fetch a response:
-
-```bash
-ros2 service call /altinet/llm/prompt altinet_interfaces/srv/PromptLLM "{
-  prompt: 'Summarise the latest living_room activity feed',
-  max_tokens: 128,
-  temperature: 0.6
-}"
-```
-
-The service returns the generated `response` text together with bookkeeping
-fields (`model`, `prompt_tokens`, `completion_tokens`). Leave `max_tokens` or
-`temperature` unset to fall back to the defaults configured on the node. When
-invoking the service from your own node import the generated interface and call
-it through a `Client<PromptLLM>` just like any other ROS 2 service.
-
-
 ### Builder → Blender → Dashboard workflow
 
 The browser-based builder now supports multi-level plans, local persistence and

--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -41,31 +41,47 @@
             </noscript>
           </div>
         </div>
-        <div class="col-12 col-lg-4 col-xl-3">
-          <div class="snapshot-panel bg-light border border-2 border-secondary-subtle rounded-4 p-4 h-100">
-            <div class="d-flex flex-column gap-3 h-100">
-              <div class="d-flex flex-column gap-1">
-                <h2 class="h4 fw-semibold mb-0">Live home snapshot</h2>
-                <p class="text-muted small mb-0">Stay on top of sensor readings and conditions.</p>
-              </div>
-              <div class="text-muted small d-flex align-items-center gap-2">
-                <span class="status-indicator bg-success-subtle border border-success-subtle"></span>
-                <span>Updated {{ environment_snapshot.local_time|date:"g:i A" }} local</span>
-              </div>
-              <div class="d-grid gap-3" data-role="metrics">
-                {% for metric in dashboard_metrics %}
-                <div class="metric-card border border-2 border-secondary-subtle rounded-4 p-3">
-                  <p class="text-uppercase text-muted small fw-semibold mb-2">{{ metric.label }}</p>
-                  <p class="fs-3 fw-semibold mb-1">{{ metric.value }}</p>
-                  <p class="text-muted small mb-0">{{ metric.detail }}</p>
-                </div>
-                {% endfor %}
-              </div>
-            </div>
+        <div class="col-12 col-lg-4 col-xl-3 text-lg-start text-center">
+          <h1 class="display-5 fw-semibold mb-3">Welcome home</h1>
+          <p class="text-muted mb-4">
+            Explore a 3D overview of your connected home, exported directly
+            from the latest Blender build of your floorplan. Rotate, zoom and
+            pan to review every room and device placement.
+          </p>
+          <div class="d-grid d-sm-flex gap-2 justify-content-center justify-content-lg-start">
+            <a class="btn btn-primary btn-lg" href="{% url 'admin:index' %}">Open admin</a>
+            <a class="btn btn-outline-secondary btn-lg" href="{% url 'web:builder' %}">Edit floorplan</a>
           </div>
         </div>
       </div>
     </div>
+  </div>
+</div>
+<div class="row justify-content-center">
+  <div class="col-12 col-xl-10">
+    <section class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5">
+      <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-4">
+        <div>
+          <h2 class="h4 fw-semibold mb-2">Live home snapshot</h2>
+          <p class="text-muted mb-0">Stay on top of the latest sensor readings and conditions.</p>
+        </div>
+        <div class="text-muted small d-flex align-items-center gap-2">
+          <span class="status-indicator bg-success-subtle border border-success-subtle"></span>
+          <span>Updated {{ environment_snapshot.local_time|date:"g:i A" }} local</span>
+        </div>
+      </div>
+      <div class="row g-3 g-md-4">
+        {% for metric in dashboard_metrics %}
+        <div class="col-12 col-sm-6 col-lg-4 col-xxl-3">
+          <div class="metric-card h-100 border border-2 border-secondary-subtle rounded-4 p-3 p-xl-4">
+            <p class="text-uppercase text-muted small fw-semibold mb-2">{{ metric.label }}</p>
+            <p class="display-6 fs-2 fw-semibold mb-1">{{ metric.value }}</p>
+            <p class="text-muted small mb-0">{{ metric.detail }}</p>
+          </div>
+        </div>
+        {% endfor %}
+      </div>
+    </section>
   </div>
 </div>
 <div class="row justify-content-center mt-4">

--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -36,20 +36,3 @@
   border-radius: 999px;
   box-shadow: 0 0 0 1px rgba(25, 135, 84, 0.4);
 }
-
-.snapshot-panel {
-  background: linear-gradient(180deg, rgba(248, 249, 250, 0.9) 0%, #ffffff 100%);
-}
-
-.snapshot-panel [data-role="metrics"] {
-  flex-grow: 1;
-  overflow-y: auto;
-  padding-right: 0.25rem;
-}
-
-@media (max-width: 991.98px) {
-  .snapshot-panel [data-role="metrics"] {
-    max-height: none;
-    overflow: visible;
-  }
-}


### PR DESCRIPTION
## Summary
- revert the layout changes introduced in PR #142, restoring the previous home dashboard snapshot panel
- remove the README instructions from PR #141 about querying the assistant via ROS 2 services

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68db3ca45634832fae5a0e7cc6f80a83