### PR TITLE
Add zoom slider to home viewer

### DIFF
--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -13,32 +13,49 @@
     <div class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5 mb-4">
       <div class="row gy-4 align-items-center flex-lg-row-reverse">
         <div class="col-12 col-lg-8 col-xl-9">
-          <div
-            id="home-viewer"
-            class="viewer-shell rounded-4 border border-2 border-secondary-subtle position-relative overflow-hidden"
-            data-obj-url="{% static home_model_path %}"
-          >
-            <div class="viewer-overlay d-flex flex-column align-items-center justify-content-center gap-2" data-role="loading">
-              <div class="spinner-border text-primary" role="status">
-                <span class="visually-hidden">Loading 3D home model...</span>
+          <div class="viewer-container">
+            <div
+              id="home-viewer"
+              class="viewer-shell rounded-4 border border-2 border-secondary-subtle position-relative overflow-hidden"
+              data-obj-url="{% static home_model_path %}"
+            >
+              <div class="viewer-overlay d-flex flex-column align-items-center justify-content-center gap-2" data-role="loading">
+                <div class="spinner-border text-primary" role="status">
+                  <span class="visually-hidden">Loading 3D home model...</span>
+                </div>
+                <p class="text-muted small mb-0">Loading home model&hellip;</p>
               </div>
-              <p class="text-muted small mb-0">Loading home model&hellip;</p>
-            </div>
-            <div class="viewer-overlay d-none text-center p-4" data-role="error">
-              <h2 class="h5 fw-semibold mb-2">We couldn't load the home</h2>
-              <p class="text-muted mb-0">
-                Please refresh the page, re-export the floorplan from Blender,
-                or check that your browser supports WebGL.
-              </p>
-            </div>
-            <noscript>
-              <div class="viewer-overlay d-flex flex-column align-items-center justify-content-center gap-2 text-center p-4">
-                <h2 class="h5 fw-semibold mb-2">JavaScript required</h2>
+              <div class="viewer-overlay d-none text-center p-4" data-role="error">
+                <h2 class="h5 fw-semibold mb-2">We couldn't load the home</h2>
                 <p class="text-muted mb-0">
-                  Enable JavaScript to interact with the 3D overview of your home.
+                  Please refresh the page, re-export the floorplan from Blender,
+                  or check that your browser supports WebGL.
                 </p>
               </div>
-            </noscript>
+              <noscript>
+                <div class="viewer-overlay d-flex flex-column align-items-center justify-content-center gap-2 text-center p-4">
+                  <h2 class="h5 fw-semibold mb-2">JavaScript required</h2>
+                  <p class="text-muted mb-0">
+                    Enable JavaScript to interact with the 3D overview of your home.
+                  </p>
+                </div>
+              </noscript>
+            </div>
+            <div class="viewer-zoom-control mt-3" data-zoom-wrapper>
+              <label class="form-label visually-hidden" for="homeViewerZoom">Zoom home model</label>
+              <input
+                type="range"
+                id="homeViewerZoom"
+                class="form-range"
+                min="2"
+                max="12"
+                step="0.1"
+                value="6"
+                data-zoom-control
+                aria-describedby="homeViewerZoomHint"
+              />
+              <span id="homeViewerZoomHint" class="visually-hidden">Drag to zoom the 3D home model</span>
+            </div>
           </div>
         </div>
         <div class="col-12 col-lg-4 col-xl-3 text-lg-start text-center">

--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -9,6 +9,12 @@
   height: 100% !important;
 }
 
+.viewer-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
 .viewer-shell {
   border-style: solid;
 }
@@ -17,6 +23,23 @@
   position: absolute;
   inset: 0;
   background: rgba(255, 255, 255, 0.85);
+}
+
+.viewer-zoom-control {
+  display: flex;
+  flex-direction: column;
+  align-items: stretch;
+  width: min(100%, 22rem);
+  padding: 0.75rem 1rem;
+  border: 1px solid rgba(108, 117, 125, 0.35);
+  border-radius: 1rem;
+  background: rgba(248, 249, 252, 0.95);
+  box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.08);
+}
+
+.viewer-zoom-control input[type='range'] {
+  width: 100%;
+  accent-color: #0d6efd;
 }
 
 .metric-card {

--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -40,6 +40,59 @@ function initialiseViewer(containerEl, objUrl) {
   controls.dampingFactor = 0.05;
   controls.screenSpacePanning = false;
   controls.maxPolarAngle = Math.PI / 2.1;
+  controls.enableZoom = false;
+
+  const zoomSlider = containerEl.parentElement?.querySelector('[data-zoom-control]');
+  const sliderMinDistance = zoomSlider ? Number.parseFloat(zoomSlider.min) || 2 : 2;
+  const sliderMaxDistance = zoomSlider ? Number.parseFloat(zoomSlider.max) || 12 : 12;
+  const zoomDirection = new THREE.Vector3();
+  const zoomPosition = new THREE.Vector3();
+  let sliderInteracting = false;
+
+  const clampDistance = (value) => {
+    if (!Number.isFinite(value)) {
+      return camera.position.distanceTo(controls.target);
+    }
+    return Math.min(sliderMaxDistance, Math.max(sliderMinDistance, value));
+  };
+
+  const syncSliderToCamera = () => {
+    if (!zoomSlider) {
+      return;
+    }
+    const distance = camera.position.distanceTo(controls.target);
+    if (!Number.isFinite(distance)) {
+      return;
+    }
+    zoomSlider.value = clampDistance(distance).toString();
+  };
+
+  if (zoomSlider) {
+    syncSliderToCamera();
+
+    zoomSlider.addEventListener('input', (event) => {
+      const rawValue = Number.parseFloat(event.target.value);
+      const desiredDistance = clampDistance(rawValue);
+      zoomSlider.value = desiredDistance.toString();
+
+      zoomDirection.subVectors(camera.position, controls.target).normalize();
+      zoomPosition.copy(controls.target).addScaledVector(zoomDirection, desiredDistance);
+      camera.position.copy(zoomPosition);
+
+      sliderInteracting = true;
+      controls.update();
+      requestAnimationFrame(() => {
+        sliderInteracting = false;
+      });
+    });
+
+    controls.addEventListener('change', () => {
+      if (sliderInteracting) {
+        return;
+      }
+      syncSliderToCamera();
+    });
+  }
 
   const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
   const keyLight = new THREE.DirectionalLight(0xffffff, 0.8);


### PR DESCRIPTION
## Summary
- add an accessible zoom slider next to the home viewer
- style the slider to sit below the canvas without obscuring it
- wire the slider to camera distance while disabling wheel zoom and keeping values in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db4c66e994832f97966889cf6e2a83