### PR TITLE
Streamline homepage to focus on 3D model

### DIFF
--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -10,139 +10,41 @@
 {% block content %}
 <div class="row justify-content-center">
   <div class="col-12 col-xl-10">
-    <div class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5 mb-4">
-      <div class="row gy-4 align-items-center flex-lg-row-reverse">
-        <div class="col-12 col-lg-8 col-xl-9">
-          <div class="viewer-container">
-            <div
-              id="home-viewer"
-              class="viewer-shell rounded-4 border border-2 border-secondary-subtle position-relative overflow-hidden"
-              data-obj-url="{% static home_model_path %}"
-            >
-              <div class="viewer-overlay d-flex flex-column align-items-center justify-content-center gap-2" data-role="loading">
-                <div class="spinner-border text-primary" role="status">
-                  <span class="visually-hidden">Loading 3D home model...</span>
-                </div>
-                <p class="text-muted small mb-0">Loading home model&hellip;</p>
-              </div>
-              <div class="viewer-overlay d-none text-center p-4" data-role="error">
-                <h2 class="h5 fw-semibold mb-2">We couldn't load the home</h2>
-                <p class="text-muted mb-0">
-                  Please refresh the page, re-export the floorplan from Blender,
-                  or check that your browser supports WebGL.
-                </p>
-              </div>
-              <noscript>
-                <div class="viewer-overlay d-flex flex-column align-items-center justify-content-center gap-2 text-center p-4">
-                  <h2 class="h5 fw-semibold mb-2">JavaScript required</h2>
-                  <p class="text-muted mb-0">
-                    Enable JavaScript to interact with the 3D overview of your home.
-                  </p>
-                </div>
-              </noscript>
+    <div class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5">
+      <div class="viewer-container">
+        <div
+          id="home-viewer"
+          class="viewer-shell rounded-4 border border-2 border-secondary-subtle position-relative overflow-hidden"
+          data-obj-url="{% static home_model_path %}"
+        >
+          <div class="viewer-overlay d-flex flex-column align-items-center justify-content-center gap-2" data-role="loading">
+            <div class="spinner-border text-primary" role="status">
+              <span class="visually-hidden">Loading 3D home model...</span>
             </div>
-            <div class="viewer-zoom-control mt-3" data-zoom-wrapper>
-              <label class="form-label visually-hidden" for="homeViewerZoom">Zoom home model</label>
-              <input
-                type="range"
-                id="homeViewerZoom"
-                class="form-range"
-                min="2"
-                max="12"
-                step="0.1"
-                value="6"
-                data-zoom-control
-                aria-describedby="homeViewerZoomHint"
-              />
-              <span id="homeViewerZoomHint" class="visually-hidden">Drag to zoom the 3D home model</span>
+            <p class="text-muted small mb-0">Loading home model&hellip;</p>
+          </div>
+          <div class="viewer-overlay d-none text-center p-4" data-role="error">
+            <h2 class="h5 fw-semibold mb-2">We couldn't load the home</h2>
+            <p class="text-muted mb-0">
+              Please refresh the page, re-export the floorplan from Blender,
+              or check that your browser supports WebGL.
+            </p>
+          </div>
+          <noscript>
+            <div class="viewer-overlay d-flex flex-column align-items-center justify-content-center gap-2 text-center p-4">
+              <h2 class="h5 fw-semibold mb-2">JavaScript required</h2>
+              <p class="text-muted mb-0">
+                Enable JavaScript to interact with the 3D overview of your home.
+              </p>
             </div>
-          </div>
-        </div>
-        <div class="col-12 col-lg-4 col-xl-3 text-lg-start text-center">
-          <h1 class="display-5 fw-semibold mb-3">Welcome home</h1>
-          <p class="text-muted mb-4">
-            Explore a 3D overview of your connected home, exported directly
-            from the latest Blender build of your floorplan. Rotate, zoom and
-            pan to review every room and device placement.
-          </p>
-          <div class="d-grid d-sm-flex gap-2 justify-content-center justify-content-lg-start">
-            <a class="btn btn-primary btn-lg" href="{% url 'admin:index' %}">Open admin</a>
-            <a class="btn btn-outline-secondary btn-lg" href="{% url 'web:builder' %}">Edit floorplan</a>
-          </div>
+          </noscript>
         </div>
       </div>
     </div>
-  </div>
-</div>
-<div class="row justify-content-center">
-  <div class="col-12 col-xl-10">
-    <section class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5">
-      <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-4">
-        <div>
-          <h2 class="h4 fw-semibold mb-2">Live home snapshot</h2>
-          <p class="text-muted mb-0">Stay on top of the latest sensor readings and conditions.</p>
-        </div>
-        <div class="text-muted small d-flex align-items-center gap-2">
-          <span class="status-indicator bg-success-subtle border border-success-subtle"></span>
-          <span>Updated {{ environment_snapshot.local_time|date:"g:i A" }} local</span>
-        </div>
-      </div>
-      <div class="row g-3 g-md-4">
-        {% for metric in dashboard_metrics %}
-        <div class="col-12 col-sm-6 col-lg-4 col-xxl-3">
-          <div class="metric-card h-100 border border-2 border-secondary-subtle rounded-4 p-3 p-xl-4">
-            <p class="text-uppercase text-muted small fw-semibold mb-2">{{ metric.label }}</p>
-            <p class="display-6 fs-2 fw-semibold mb-1">{{ metric.value }}</p>
-            <p class="text-muted small mb-0">{{ metric.detail }}</p>
-          </div>
-        </div>
-        {% endfor %}
-      </div>
-    </section>
-  </div>
-</div>
-<div class="row justify-content-center mt-4">
-  <div class="col-12 col-xl-10">
-    <section class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-4 p-md-5">
-      <div class="d-flex flex-column flex-md-row justify-content-between gap-3 mb-4">
-        <div>
-          <h2 class="h4 fw-semibold mb-2">Ask the Altinet assistant</h2>
-          <p class="text-muted mb-0">Summarize readings, plan automations, or get quick insights.</p>
-        </div>
-      </div>
-      <form class="mb-4" data-llm-form>
-        <div class="mb-3">
-          <label class="form-label" for="llmPromptInput">Describe what you need</label>
-          <textarea
-            id="llmPromptInput"
-            class="form-control"
-            rows="4"
-            placeholder="Explain the current weather outlook or draft a new automation trigger..."
-            required
-            data-llm-input
-          ></textarea>
-        </div>
-        <div class="d-flex flex-column flex-sm-row align-items-sm-center gap-3">
-          <button type="submit" class="btn btn-primary" data-llm-submit>Send to assistant</button>
-          <div class="text-muted small" data-llm-status aria-live="polite"></div>
-        </div>
-      </form>
-      <div>
-        <h3 class="h5 fw-semibold mb-2">Assistant response</h3>
-        <div
-          class="bg-light border border-secondary-subtle rounded-3 p-3"
-          data-llm-response
-          aria-live="polite"
-        >
-          Responses will appear here once you submit a prompt.
-        </div>
-      </div>
-    </section>
   </div>
 </div>
 {% endblock %}
 
 {% block extra_scripts %}
 <script type="module" src="{% static 'web/js/home-viewer.js' %}"></script>
-<script type="module" src="{% static 'web/js/home-llm.js' %}"></script>
 {% endblock %}

--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -24,38 +24,3 @@
   inset: 0;
   background: rgba(255, 255, 255, 0.85);
 }
-
-.viewer-zoom-control {
-  display: flex;
-  flex-direction: column;
-  align-items: stretch;
-  width: min(100%, 22rem);
-  padding: 0.75rem 1rem;
-  border: 1px solid rgba(108, 117, 125, 0.35);
-  border-radius: 1rem;
-  background: rgba(248, 249, 252, 0.95);
-  box-shadow: 0 0.5rem 1rem rgba(15, 23, 42, 0.08);
-}
-
-.viewer-zoom-control input[type='range'] {
-  width: 100%;
-  accent-color: #0d6efd;
-}
-
-.metric-card {
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-  background-color: #fdfdff;
-}
-
-.metric-card:hover,
-.metric-card:focus-within {
-  transform: translateY(-2px);
-  box-shadow: 0 0.75rem 1.5rem rgba(15, 23, 42, 0.08);
-}
-
-.status-indicator {
-  width: 0.75rem;
-  height: 0.75rem;
-  border-radius: 999px;
-  box-shadow: 0 0 0 1px rgba(25, 135, 84, 0.4);
-}

--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -42,58 +42,6 @@ function initialiseViewer(containerEl, objUrl) {
   controls.maxPolarAngle = Math.PI / 2.1;
   controls.enableZoom = false;
 
-  const zoomSlider = containerEl.parentElement?.querySelector('[data-zoom-control]');
-  const sliderMinDistance = zoomSlider ? Number.parseFloat(zoomSlider.min) || 2 : 2;
-  const sliderMaxDistance = zoomSlider ? Number.parseFloat(zoomSlider.max) || 12 : 12;
-  const zoomDirection = new THREE.Vector3();
-  const zoomPosition = new THREE.Vector3();
-  let sliderInteracting = false;
-
-  const clampDistance = (value) => {
-    if (!Number.isFinite(value)) {
-      return camera.position.distanceTo(controls.target);
-    }
-    return Math.min(sliderMaxDistance, Math.max(sliderMinDistance, value));
-  };
-
-  const syncSliderToCamera = () => {
-    if (!zoomSlider) {
-      return;
-    }
-    const distance = camera.position.distanceTo(controls.target);
-    if (!Number.isFinite(distance)) {
-      return;
-    }
-    zoomSlider.value = clampDistance(distance).toString();
-  };
-
-  if (zoomSlider) {
-    syncSliderToCamera();
-
-    zoomSlider.addEventListener('input', (event) => {
-      const rawValue = Number.parseFloat(event.target.value);
-      const desiredDistance = clampDistance(rawValue);
-      zoomSlider.value = desiredDistance.toString();
-
-      zoomDirection.subVectors(camera.position, controls.target).normalize();
-      zoomPosition.copy(controls.target).addScaledVector(zoomDirection, desiredDistance);
-      camera.position.copy(zoomPosition);
-
-      sliderInteracting = true;
-      controls.update();
-      requestAnimationFrame(() => {
-        sliderInteracting = false;
-      });
-    });
-
-    controls.addEventListener('change', () => {
-      if (sliderInteracting) {
-        return;
-      }
-      syncSliderToCamera();
-    });
-  }
-
   const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
   const keyLight = new THREE.DirectionalLight(0xffffff, 0.8);
   keyLight.position.set(5, 10, 7);


### PR DESCRIPTION
## Summary
- simplify the dashboard template so the homepage only renders the 3D model viewer
- remove unused zoom slider styling and logic from the associated CSS and viewer script

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68db4fbe3528832fbd63bdaabf2a437a