### PR TITLE
Clamp home viewer zoom distance

### DIFF
--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -107,12 +107,18 @@ function prepareModel(model, scene, controls) {
   const size = new THREE.Vector3();
   box.getSize(size);
 
+  const diagonal = size.length();
+  const minDistance = Math.max(diagonal * 0.35 || 0, 0.75);
+  const maxDistance = Math.max(diagonal * 4 || 0, minDistance * 2);
+
   model.position.sub(target);
   model.position.y -= box.min.y;
 
   scene.add(model);
 
   controls.target.set(0, size.y * 0.45, 0);
+  controls.minDistance = minDistance;
+  controls.maxDistance = maxDistance;
   controls.update();
 }
 


### PR DESCRIPTION
## Summary
- derive the model bounding diagonal during preparation and use it to clamp orbit control distances
- prevent the home viewer camera from dollying through the mesh by enforcing min/max zoom limits

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db670c01d4832fae606662200d2d7a