### PR TITLE
Refine home dashboard layout

### DIFF
--- a/backend/templates/web/base.html
+++ b/backend/templates/web/base.html
@@ -14,7 +14,7 @@
     />
     {% block extra_head %}{% endblock %}
   </head>
-  <body class="bg-light">
+  <body class="bg-light {% block body_class %}{% endblock %}">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid">
         <a class="navbar-brand" href="{% url 'web:home' %}">Altinet</a>

--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -7,10 +7,98 @@
 <link rel="stylesheet" href="{% static 'web/css/home.css' %}" />
 {% endblock %}
 
+{% block body_class %}home-page{% endblock %}
+
 {% block content %}
-<div class="row justify-content-center">
-  <div class="col-12 col-xl-11">
-    <div class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-3 p-md-4 p-xl-5 mb-4">
+<div class="row g-4 align-items-stretch home-layout">
+  <div class="col-12 col-xl-4 col-xxl-3">
+    <section class="environment-card bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm h-100 p-3 p-lg-4">
+      <div class="d-flex flex-column h-100">
+        <header class="mb-4">
+          <p class="text-uppercase text-primary fw-semibold small mb-1">Live environment</p>
+          <h1 class="h4 fw-semibold mb-0">Your home at a glance</h1>
+        </header>
+        <div class="mb-4">
+          <p class="display-6 fw-semibold mb-1">{{ environment_snapshot.local_time|date:"g:i A" }}</p>
+          <p class="text-muted mb-0">{{ environment_snapshot.local_time|date:"l, F j" }}</p>
+        </div>
+        <div class="environment-metrics row row-cols-1 row-cols-sm-2 g-3">
+          <div class="col">
+            <article class="environment-metric h-100">
+              <h2 class="h6 text-uppercase text-muted mb-2">People present</h2>
+              <p class="metric-value mb-0">{{ environment_snapshot.people_present }}</p>
+            </article>
+          </div>
+          <div class="col">
+            <article class="environment-metric h-100">
+              <h2 class="h6 text-uppercase text-muted mb-2">Occupants</h2>
+              {% if environment_snapshot.people_list %}
+                <ul class="metric-list mb-0">
+                  {% for person in environment_snapshot.people_list %}
+                    <li>{{ person }}</li>
+                  {% endfor %}
+                </ul>
+              {% else %}
+                <p class="metric-placeholder mb-0">No occupants detected</p>
+              {% endif %}
+            </article>
+          </div>
+          <div class="col">
+            <article class="environment-metric h-100">
+              <h2 class="h6 text-uppercase text-muted mb-2">Outside temperature</h2>
+              <p class="metric-value mb-0">
+                {% if environment_snapshot.outside_temperature_c is not None %}
+                  {{ environment_snapshot.outside_temperature_c|floatformat:1 }}°C
+                {% else %}
+                  —
+                {% endif %}
+              </p>
+            </article>
+          </div>
+          <div class="col">
+            <article class="environment-metric h-100">
+              <h2 class="h6 text-uppercase text-muted mb-2">Average indoor temperature</h2>
+              <p class="metric-value mb-0">
+                {% if environment_snapshot.average_indoor_temperature_c is not None %}
+                  {{ environment_snapshot.average_indoor_temperature_c|floatformat:1 }}°C
+                {% else %}
+                  —
+                {% endif %}
+              </p>
+            </article>
+          </div>
+          <div class="col">
+            <article class="environment-metric h-100">
+              <h2 class="h6 text-uppercase text-muted mb-2">Wind</h2>
+              <p class="metric-value mb-0">
+                {% if environment_snapshot.wind_speed_kmh is not None %}
+                  {{ environment_snapshot.wind_speed_kmh|floatformat:1 }} km/h
+                  {% if environment_snapshot.wind_direction_cardinal %}
+                    <span class="text-muted">({{ environment_snapshot.wind_direction_cardinal }})</span>
+                  {% endif %}
+                {% else %}
+                  —
+                {% endif %}
+              </p>
+            </article>
+          </div>
+          <div class="col">
+            <article class="environment-metric h-100">
+              <h2 class="h6 text-uppercase text-muted mb-2">Local weather</h2>
+              <p class="metric-value mb-0">{{ environment_snapshot.weather_summary|default:"—" }}</p>
+            </article>
+          </div>
+        </div>
+        <div class="mt-auto pt-4">
+          <p class="text-muted small mb-0">
+            Data updates automatically as new sensor readings arrive.
+          </p>
+        </div>
+      </div>
+    </section>
+  </div>
+  <div class="col-12 col-xl-8 col-xxl-9">
+    <div class="bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm p-3 p-lg-4 h-100">
       <div
         id="home-viewer"
         class="viewer-shell rounded-4 border border-2 border-secondary-subtle position-relative overflow-hidden"

--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -18,3 +18,56 @@
   inset: 0;
   background: rgba(255, 255, 255, 0.85);
 }
+
+.home-page main.container {
+  max-width: 100%;
+  padding-left: clamp(0.75rem, 2vw, 2rem);
+  padding-right: clamp(0.75rem, 2vw, 2rem);
+}
+
+.home-layout {
+  --bs-gutter-x: 1.25rem;
+  --bs-gutter-y: 1.25rem;
+}
+
+.environment-card {
+  min-height: 100%;
+}
+
+.environment-metrics {
+  margin: 0;
+}
+
+.environment-metric {
+  background: var(--bs-tertiary-bg);
+  border: 1px solid var(--bs-border-color-translucent);
+  border-radius: 1rem;
+  padding: 1rem;
+}
+
+.environment-metric .metric-value {
+  font-size: 1.5rem;
+  font-weight: 600;
+}
+
+.environment-metric .metric-list {
+  list-style: none;
+  padding: 0;
+  font-size: 0.95rem;
+}
+
+.environment-metric .metric-placeholder {
+  color: var(--bs-secondary-color);
+  font-size: 0.95rem;
+}
+
+@media (min-width: 1200px) {
+  .home-layout {
+    --bs-gutter-x: 1.75rem;
+    --bs-gutter-y: 1.75rem;
+  }
+
+  .environment-metric {
+    padding: 1.25rem;
+  }
+}

--- a/backend/web/tests/test_weather.py
+++ b/backend/web/tests/test_weather.py
@@ -49,6 +49,7 @@ def test_fetch_weather_snapshot_parses_weather(monkeypatch: pytest.MonkeyPatch) 
                         "temperature": 20.1,
                         "weathercode": 2,
                         "windspeed": 12.3,
+                        "winddirection": 225,
                         "time": "2024-01-01T12:00",
                     },
                     "hourly": {
@@ -75,6 +76,7 @@ def test_fetch_weather_snapshot_parses_weather(monkeypatch: pytest.MonkeyPatch) 
         "outside_humidity": 55,
         "weather_summary": "Partly cloudy",
         "wind_speed_kmh": 12.3,
+        "wind_direction_deg": 225,
         "air_quality_index": 42,
     }
 

--- a/backend/web/views.py
+++ b/backend/web/views.py
@@ -11,6 +11,26 @@ from .models import SystemSettings
 from .weather import fetch_weather_snapshot
 
 
+def _wind_direction_to_cardinal(degrees: float | None) -> str | None:
+    """Convert a wind direction in degrees to a cardinal label."""
+
+    if degrees is None:
+        return None
+
+    cardinal_points = [
+        "N",
+        "NE",
+        "E",
+        "SE",
+        "S",
+        "SW",
+        "W",
+        "NW",
+    ]
+    index = int((degrees % 360) / 45 + 0.5) % len(cardinal_points)
+    return cardinal_points[index]
+
+
 @login_required
 def home(request):
     """Render the main dashboard once the user is authenticated."""
@@ -18,11 +38,15 @@ def home(request):
 
     environment_snapshot = {
         "people_present": 0,
+        "people_list": [],
         "local_time": local_now,
         "outside_temperature_c": None,
         "outside_humidity": None,
+        "average_indoor_temperature_c": None,
         "weather_summary": None,
         "wind_speed_kmh": None,
+        "wind_direction_deg": None,
+        "wind_direction_cardinal": None,
         "air_quality_index": None,
         "energy_usage_kw": None,
     }
@@ -30,6 +54,9 @@ def home(request):
     system_settings = SystemSettings.load()
     weather_snapshot = fetch_weather_snapshot(system_settings.home_address)
     environment_snapshot.update(weather_snapshot)
+    environment_snapshot["wind_direction_cardinal"] = _wind_direction_to_cardinal(
+        environment_snapshot.get("wind_direction_deg")
+    )
 
     dashboard_metrics = [
         {

--- a/backend/web/weather.py
+++ b/backend/web/weather.py
@@ -49,6 +49,7 @@ class WeatherSnapshot:
     humidity_percent: Optional[int] = None
     summary: Optional[str] = None
     wind_speed_kmh: Optional[float] = None
+    wind_direction_deg: Optional[float] = None
     air_quality_index: Optional[int] = None
 
     def as_environment_fields(self) -> Dict[str, Any]:
@@ -59,6 +60,7 @@ class WeatherSnapshot:
             "outside_humidity": self.humidity_percent,
             "weather_summary": self.summary,
             "wind_speed_kmh": self.wind_speed_kmh,
+            "wind_direction_deg": self.wind_direction_deg,
             "air_quality_index": self.air_quality_index,
         }
 
@@ -143,6 +145,7 @@ def fetch_weather_snapshot(address: str) -> Dict[str, Any]:
             else None,
             summary=_parse_weather_summary(current_weather.get("weathercode")),
             wind_speed_kmh=current_weather.get("windspeed"),
+            wind_direction_deg=current_weather.get("winddirection"),
         )
 
         air_quality_response = httpx.get(


### PR DESCRIPTION
## Summary
- add a live environment information card alongside the 3D home model
- surface additional weather data including wind direction in both the UI and backend context
- reorganize the dashboard layout with two-column metric cards and reduced outer padding for a tighter fit

## Testing
- pytest backend/web/tests

------
https://chatgpt.com/codex/tasks/task_e_68db712c12e0832fb75b26271902365f