### PR TITLE
Add automatic TinyLlama detection for the LLM endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,13 @@ offline LLaMA model configured through environment variables. To enable the
 assistant locally:
 
 1. Point the backend at your `llama.cpp` compatible weights and optional
-   generation settings before starting Django:
+   generation settings before starting Django. A copy of
+   `tinyllama-1.1b-chat-v1.0.Q2_K.gguf` placed in
+   `assets/models/` is detected automatically, otherwise configure the path
+   manually:
 
    ```bash
-   export ALTINET_LLAMA_MODEL_PATH=/absolute/path/to/ggml-model.bin
+   export ALTINET_LLAMA_MODEL_PATH=/absolute/path/to/ggml-model.bin  # optional when using the default TinyLlama weight
    export ALTINET_LLAMA_CONTEXT=2048            # optional
    export ALTINET_LLAMA_MAX_TOKENS=256          # optional
    export ALTINET_LLAMA_TEMPERATURE=0.7         # optional

--- a/backend/altinet_backend/settings.py
+++ b/backend/altinet_backend/settings.py
@@ -183,7 +183,14 @@ ROS_BRIDGE_BASE_URL = os.environ.get("ROS_BRIDGE_URL", "http://localhost:8001")
 ROS_BRIDGE_WS_URL = os.environ.get("ROS_BRIDGE_WS_URL", "ws://localhost:8001")
 
 # Offline LLaMA configuration
-LLAMA_MODEL_PATH = os.environ.get("ALTINET_LLAMA_MODEL_PATH", "")
+_default_llama_model = BASE_DIR.parent / "assets" / "models" / "tinyllama-1.1b-chat-v1.0.Q2_K.gguf"
+_configured_llama_model = os.environ.get("ALTINET_LLAMA_MODEL_PATH")
+if _configured_llama_model:
+    LLAMA_MODEL_PATH = _configured_llama_model
+elif _default_llama_model.exists():
+    LLAMA_MODEL_PATH = str(_default_llama_model)
+else:
+    LLAMA_MODEL_PATH = ""
 LLAMA_CONTEXT_WINDOW = int(os.environ.get("ALTINET_LLAMA_CONTEXT", "2048"))
 LLAMA_MAX_TOKENS = int(os.environ.get("ALTINET_LLAMA_MAX_TOKENS", "256"))
 LLAMA_TEMPERATURE = float(os.environ.get("ALTINET_LLAMA_TEMPERATURE", "0.7"))


### PR DESCRIPTION
## Summary
- automatically configure the offline LLaMA service to use the bundled TinyLlama weights when available
- update the LLM documentation to mention the default model detection and clarify the environment variable usage

## Testing
- pytest backend/llm/tests/test_views.py

------
https://chatgpt.com/codex/tasks/task_e_68db82256204832fa8aa7124ac736251