### PR TITLE
Move settings link next to builder in navbar

### DIFF
--- a/backend/templates/web/base.html
+++ b/backend/templates/web/base.html
@@ -52,19 +52,15 @@
                 Home
               </a>
             </li>
-            {% if user.is_authenticated %}
-            <li class="nav-item">
-              <a
-                class="nav-link {% if request.resolver_match.url_name == 'settings' %}active{% endif %}"
-                href="{% url 'web:settings' %}"
-              >
-                Settings
-              </a>
-            </li>
-            {% endif %}
           </ul>
           <div class="d-flex align-items-center gap-2">
             {% if user.is_authenticated %}
+            <a
+              class="btn btn-outline-light {% if request.resolver_match.url_name == 'settings' %}active{% endif %}"
+              href="{% url 'web:settings' %}"
+            >
+              Settings
+            </a>
             <a
               class="btn btn-outline-light {% if request.resolver_match.url_name == 'builder' %}active{% endif %}"
               href="{% url 'web:builder' %}"


### PR DESCRIPTION
## Summary
- move the settings link into the authenticated user action area on the right of the navbar
- ensure the settings button sits immediately to the left of the builder button

## Testing
- not run (dependencies could not be installed due to proxy restrictions)


------
https://chatgpt.com/codex/tasks/task_e_68db8f98ac60832f8cce0a03d5500f1c