### PR TITLE
Use browser local time for dashboard clock

### DIFF
--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -19,8 +19,12 @@
           <h1 class="h4 fw-semibold mb-0">Your home at a glance</h1>
         </header>
         <div class="mb-4">
-          <p class="display-6 fw-semibold mb-1">{{ environment_snapshot.local_time|date:"g:i A" }}</p>
-          <p class="text-muted mb-0">{{ environment_snapshot.local_time|date:"l, F j" }}</p>
+          <p id="local-time-display" class="display-6 fw-semibold mb-1">
+            {{ environment_snapshot.local_time|date:"g:i A" }}
+          </p>
+          <p id="local-date-display" class="text-muted mb-0">
+            {{ environment_snapshot.local_time|date:"l, F j" }}
+          </p>
         </div>
         <div class="environment-metrics row row-cols-1 row-cols-sm-2 g-3">
           <div class="col">
@@ -133,4 +137,5 @@
 
 {% block extra_scripts %}
 <script type="module" src="{% static 'web/js/home-viewer.js' %}"></script>
+<script type="module" src="{% static 'web/js/home-local-time.js' %}"></script>
 {% endblock %}

--- a/backend/web/static/web/js/home-local-time.js
+++ b/backend/web/static/web/js/home-local-time.js
@@ -1,0 +1,25 @@
+const timeElement = document.getElementById("local-time-display");
+const dateElement = document.getElementById("local-date-display");
+
+if (timeElement && dateElement) {
+  const updateLocalTime = () => {
+    const now = new Date();
+
+    const timeFormatter = new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+
+    const dateFormatter = new Intl.DateTimeFormat(undefined, {
+      weekday: "long",
+      month: "long",
+      day: "numeric",
+    });
+
+    timeElement.textContent = timeFormatter.format(now);
+    dateElement.textContent = dateFormatter.format(now);
+  };
+
+  updateLocalTime();
+  window.setInterval(updateLocalTime, 30_000);
+}


### PR DESCRIPTION
## Summary
- add identifiers to the dashboard clock display so it can be updated client-side
- render the home page clock with the browser's locale-aware system time using a new script

## Testing
- No automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68db8cec635c832fa138a485fed53166