### PR TITLE
Improve mobile pinch zoom support on home viewer

### DIFF
--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -7,6 +7,7 @@
   display: block;
   width: 100% !important;
   height: 100% !important;
+  touch-action: none;
 }
 
 .viewer-shell {

--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -148,6 +148,15 @@ function setupSmoothScrollZoom(controls, camera, domElement, distances) {
 
   controls.enableZoom = false;
 
+  if (domElement.style.touchAction !== 'none') {
+    domElement.style.touchAction = 'none';
+  }
+
+  const baseControlState = {
+    enablePan: controls.enablePan,
+    enableRotate: controls.enableRotate,
+  };
+
   const handleWheel = (event) => {
     if (event.defaultPrevented) {
       return;
@@ -188,6 +197,8 @@ function setupSmoothScrollZoom(controls, camera, domElement, distances) {
   };
 
   const handleTouchStart = (event) => {
+    event.stopPropagation();
+
     if (event.touches.length !== 2) {
       return;
     }
@@ -196,12 +207,19 @@ function setupSmoothScrollZoom(controls, camera, domElement, distances) {
       return;
     }
 
+    event.preventDefault();
+
+    controls.enableRotate = false;
+    controls.enablePan = false;
+
     touchState.active = true;
     touchState.initialDistance = distance;
     touchState.initialTargetDistance = targetDistance;
   };
 
   const handleTouchMove = (event) => {
+    event.stopPropagation();
+
     if (!touchState.active) {
       return;
     }
@@ -229,9 +247,13 @@ function setupSmoothScrollZoom(controls, camera, domElement, distances) {
     touchState.active = false;
     touchState.initialDistance = 0;
     touchState.initialTargetDistance = targetDistance;
+    controls.enableRotate = baseControlState.enableRotate;
+    controls.enablePan = baseControlState.enablePan;
   };
 
   const handleTouchEnd = (event) => {
+    event.stopPropagation();
+
     if (event.touches.length === 2) {
       // Another finger lifted but two touches remain; refresh the baseline.
       touchState.initialDistance = distanceBetweenTouches(event.touches);
@@ -244,7 +266,7 @@ function setupSmoothScrollZoom(controls, camera, domElement, distances) {
     }
   };
 
-  domElement.addEventListener('touchstart', handleTouchStart, { passive: true });
+  domElement.addEventListener('touchstart', handleTouchStart, { passive: false });
   domElement.addEventListener('touchmove', handleTouchMove, { passive: false });
   domElement.addEventListener('touchend', handleTouchEnd, { passive: true });
   domElement.addEventListener('touchcancel', handleTouchEnd, { passive: true });


### PR DESCRIPTION
## Summary
- ensure pinch gestures temporarily disable camera pan/rotate so zooming responds immediately
- mark the viewer canvas with touch-action none to consistently route multi-touch events to the custom zoom logic

## Testing
- Not run (front-end only change)


------
https://chatgpt.com/codex/tasks/task_e_68dba6ff0304832fbd717a53bcff0bae