### PR TITLE
Improve mobile pinch zoom support on home viewer

### DIFF
--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -7,6 +7,7 @@
   display: block;
   width: 100% !important;
   height: 100% !important;
+  touch-action: none;
 }
 
 .viewer-shell {


### PR DESCRIPTION
## Summary
- ensure pinch gestures temporarily disable camera pan/rotate so zooming responds immediately
- mark the viewer canvas with touch-action none to consistently route multi-touch events to the custom zoom logic
- detect coarse touch devices with PointerEvents so mobile browsers trigger pinch zoom, and fall back to touch listeners when PointerEvents are unavailable

## Testing
- Not run (front-end only change)

------
https://chatgpt.com/codex/tasks/task_e_68dba6ff0304832fbd717a53bcff0bae