### PR TITLE
Add asynchronous Macleay Island weather scraping for dashboard

### DIFF
--- a/backend/templates/web/home.html
+++ b/backend/templates/web/home.html
@@ -12,7 +12,10 @@
 {% block content %}
 <div class="row g-4 align-items-stretch home-layout">
   <div class="col-12 col-xl-4 col-xxl-3">
-    <section class="environment-card bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm h-100 p-3 p-lg-4">
+    <section
+      class="environment-card bg-white border border-2 border-secondary-subtle rounded-4 shadow-sm h-100 p-3 p-lg-4"
+      data-weather-endpoint="{{ weather_endpoint }}"
+    >
       <div class="d-flex flex-column h-100">
         <header class="mb-4">
           <p class="text-uppercase text-primary fw-semibold small mb-1">Live environment</p>
@@ -50,7 +53,11 @@
           <div class="col">
             <article class="environment-metric h-100">
               <h2 class="h6 text-uppercase text-muted mb-2">Outside temperature</h2>
-              <p class="metric-value mb-0">
+              <p
+                class="metric-value mb-0"
+                data-weather-field="outside_temperature_c"
+                data-weather-format="temperature"
+              >
                 {% if environment_snapshot.outside_temperature_c is not None %}
                   {{ environment_snapshot.outside_temperature_c|floatformat:1 }}°C
                 {% else %}
@@ -75,27 +82,83 @@
             <article class="environment-metric h-100">
               <h2 class="h6 text-uppercase text-muted mb-2">Wind</h2>
               <p class="metric-value mb-0">
-                {% if environment_snapshot.wind_speed_kmh is not None %}
-                  {{ environment_snapshot.wind_speed_kmh|floatformat:1 }} km/h
-                  {% if environment_snapshot.wind_direction_cardinal %}
-                    <span class="text-muted">({{ environment_snapshot.wind_direction_cardinal }})</span>
+                <span
+                  data-weather-field="wind_speed_kmh"
+                  data-weather-format="wind-speed"
+                >
+                  {% if environment_snapshot.wind_speed_kmh is not None %}
+                    {{ environment_snapshot.wind_speed_kmh|floatformat:1 }} km/h
+                  {% else %}
+                    —
                   {% endif %}
-                {% else %}
-                  —
-                {% endif %}
+                </span>
+                <span
+                  class="text-muted"
+                  data-weather-field="wind_direction_cardinal"
+                  data-weather-format="wind-direction"
+                >
+                  {% if environment_snapshot.wind_speed_kmh is not None and environment_snapshot.wind_direction_cardinal %}
+                    ({{ environment_snapshot.wind_direction_cardinal }})
+                  {% endif %}
+                </span>
               </p>
             </article>
           </div>
           <div class="col">
             <article class="environment-metric h-100">
               <h2 class="h6 text-uppercase text-muted mb-2">Local weather</h2>
-              <p class="metric-value mb-0">{{ environment_snapshot.weather_summary|default:"—" }}</p>
+              <p
+                class="metric-value mb-0"
+                data-weather-field="weather_summary"
+              >
+                {{ environment_snapshot.weather_summary|default:"—" }}
+              </p>
             </article>
           </div>
         </div>
-        <div class="mt-auto pt-4">
-          <p class="text-muted small mb-0">
-            Data updates automatically as new sensor readings arrive.
+        <div class="mt-4">
+          <h2 class="h6 text-uppercase text-muted mb-3">Detailed outdoor weather</h2>
+          <div class="table-responsive">
+            <table class="table table-sm mb-2 environment-weather-table">
+              <tbody>
+                <tr>
+                  <th scope="row" class="text-nowrap">Temperature</th>
+                  <td
+                    data-weather-field="outside_temperature_c"
+                    data-weather-format="temperature"
+                  >
+                    —
+                  </td>
+                </tr>
+                <tr>
+                  <th scope="row" class="text-nowrap">Humidity</th>
+                  <td data-weather-field="outside_humidity" data-weather-format="percentage">—</td>
+                </tr>
+                <tr>
+                  <th scope="row" class="text-nowrap">Weather</th>
+                  <td data-weather-field="weather_summary">—</td>
+                </tr>
+                <tr>
+                  <th scope="row" class="text-nowrap">Wind speed</th>
+                  <td data-weather-field="wind_speed_kmh" data-weather-format="wind-speed">—</td>
+                </tr>
+                <tr>
+                  <th scope="row" class="text-nowrap">Wind direction</th>
+                  <td data-weather-field="wind_direction_cardinal" data-weather-format="text">—</td>
+                </tr>
+                <tr>
+                  <th scope="row" class="text-nowrap">Wind bearing</th>
+                  <td data-weather-field="wind_direction_deg" data-weather-format="degrees">—</td>
+                </tr>
+                <tr>
+                  <th scope="row" class="text-nowrap">Air quality</th>
+                  <td data-weather-field="air_quality_index" data-weather-format="aqi">—</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p class="text-muted small mb-0" data-weather-status>
+            Gathering latest readings for Macleay Island&hellip;
           </p>
         </div>
       </div>
@@ -171,4 +234,5 @@
 <script src="{% static 'web/js/home-llm.js' %}" defer></script>
 
 <script type="module" src="{% static 'web/js/home-local-time.js' %}"></script>
+<script type="module" src="{% static 'web/js/home-weather.js' %}"></script>
 {% endblock %}

--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -62,6 +62,19 @@
   font-size: 0.95rem;
 }
 
+.environment-weather-table {
+  font-size: 0.95rem;
+}
+
+.environment-weather-table td {
+  font-variant-numeric: tabular-nums;
+}
+
+.environment-weather-table th {
+  width: 1%;
+  white-space: nowrap;
+}
+
 .assistant-card {
   min-height: 100%;
 }

--- a/backend/web/static/web/js/home-weather.js
+++ b/backend/web/static/web/js/home-weather.js
@@ -1,0 +1,184 @@
+const container = document.querySelector("[data-weather-endpoint]");
+
+if (container) {
+  const endpoint = container.dataset.weatherEndpoint;
+  const statusElement = container.querySelector("[data-weather-status]");
+  const REFRESH_INTERVAL_MS = 10 * 60 * 1000;
+
+  const fieldElements = Array.from(
+    container.querySelectorAll("[data-weather-field]")
+  );
+
+  const asNumber = (value) => {
+    if (typeof value === "number") {
+      return value;
+    }
+    if (typeof value === "string" && value.trim() !== "") {
+      const parsed = Number.parseFloat(value);
+      if (Number.isFinite(parsed)) {
+        return parsed;
+      }
+    }
+    return null;
+  };
+
+  const formatters = {
+    temperature(value) {
+      const numeric = asNumber(value);
+      if (numeric === null) {
+        return "—";
+      }
+      return `${numeric.toFixed(1)}°C`;
+    },
+    percentage(value) {
+      const numeric = asNumber(value);
+      if (numeric === null) {
+        return "—";
+      }
+      return `${Math.round(numeric)}%`;
+    },
+    "wind-speed"(value) {
+      const numeric = asNumber(value);
+      if (numeric === null) {
+        return "—";
+      }
+      return `${numeric.toFixed(1)} km/h`;
+    },
+    "wind-direction"(value) {
+      if (!value) {
+        return "";
+      }
+      return `(${value})`;
+    },
+    degrees(value) {
+      const numeric = asNumber(value);
+      if (numeric === null) {
+        return "—";
+      }
+      return `${Math.round(numeric)}°`;
+    },
+    aqi(value) {
+      const numeric = asNumber(value);
+      if (numeric === null) {
+        return "—";
+      }
+      return `AQI ${Math.round(numeric)}`;
+    },
+    text(value) {
+      if (value === null || value === undefined || value === "") {
+        return "—";
+      }
+      return String(value);
+    },
+  };
+
+  const setStatus = (message, isError = false) => {
+    if (!statusElement) {
+      return;
+    }
+    statusElement.textContent = message;
+    if (isError) {
+      statusElement.classList.add("text-danger");
+      statusElement.classList.remove("text-muted");
+    } else {
+      statusElement.classList.remove("text-danger");
+      if (!statusElement.classList.contains("text-muted")) {
+        statusElement.classList.add("text-muted");
+      }
+    }
+  };
+
+  const applyWeatherData = (data) => {
+    fieldElements.forEach((element) => {
+      const field = element.dataset.weatherField;
+      const format = element.dataset.weatherFormat || "text";
+      const rawValue = data[field];
+      const formatter = formatters[format] || formatters.text;
+
+      if (format === "wind-direction") {
+        if (!rawValue) {
+          element.textContent = "";
+          element.setAttribute("hidden", "hidden");
+          return;
+        }
+        element.removeAttribute("hidden");
+        element.textContent = formatter(rawValue);
+        return;
+      }
+
+      if (rawValue === null || rawValue === undefined || rawValue === "") {
+        element.textContent = "—";
+        return;
+      }
+
+      try {
+        element.textContent = formatter(rawValue);
+      } catch (error) {
+        console.error("Unable to format weather field", field, error);
+        element.textContent = String(rawValue);
+      }
+    });
+  };
+
+  const updateStatusTimestamp = (retrievedAt) => {
+    if (!statusElement) {
+      return;
+    }
+
+    const timestamp = retrievedAt ? new Date(retrievedAt) : new Date();
+    if (Number.isNaN(timestamp.getTime())) {
+      setStatus("Latest conditions updated.");
+      return;
+    }
+
+    const formatter = new Intl.DateTimeFormat(undefined, {
+      hour: "numeric",
+      minute: "2-digit",
+    });
+
+    setStatus(`Updated ${formatter.format(timestamp)} local time.`);
+  };
+
+  const loadWeather = async () => {
+    if (!endpoint) {
+      return;
+    }
+
+    try {
+      const response = await fetch(endpoint, {
+        headers: { Accept: "application/json" },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Request failed with status ${response.status}`);
+      }
+
+      const payload = await response.json();
+      if (!payload.success || !payload.data) {
+        throw new Error("Response did not include weather data");
+      }
+
+      applyWeatherData(payload.data);
+      updateStatusTimestamp(payload.retrieved_at);
+    } catch (error) {
+      console.error("Failed to load weather data", error);
+      setStatus("Unable to load latest weather for Macleay Island.", true);
+    } finally {
+      window.setTimeout(loadWeather, REFRESH_INTERVAL_MS);
+    }
+  };
+
+  const startFetching = () => {
+    if (!endpoint) {
+      setStatus("Weather endpoint is not configured.", true);
+      return;
+    }
+    loadWeather();
+  };
+
+  if ("requestIdleCallback" in window) {
+    window.requestIdleCallback(startFetching);
+  } else {
+    window.setTimeout(startFetching, 150);
+  }
+}

--- a/backend/web/urls.py
+++ b/backend/web/urls.py
@@ -10,4 +10,5 @@ urlpatterns = [
     path("", views.home, name="home"),
     path("builder/", views.builder, name="builder"),
     path("settings/", views.settings_view, name="settings"),
+    path("api/weather/", views.weather_snapshot, name="weather-snapshot"),
 ]

--- a/backend/web/weather.py
+++ b/backend/web/weather.py
@@ -2,48 +2,26 @@
 
 from __future__ import annotations
 
+import json
+import math
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Iterable, Optional
 
 import httpx
 
-# Weather code mapping based on the Open-Meteo documentation:
-# https://open-meteo.com/en/docs#latitude=52.52&longitude=13.41&hourly=temperature_2m
-WEATHER_CODE_SUMMARY: Dict[int, str] = {
-    0: "Clear sky",
-    1: "Mainly clear",
-    2: "Partly cloudy",
-    3: "Overcast",
-    45: "Fog",
-    48: "Depositing rime fog",
-    51: "Light drizzle",
-    53: "Moderate drizzle",
-    55: "Dense drizzle",
-    56: "Light freezing drizzle",
-    57: "Dense freezing drizzle",
-    61: "Slight rain",
-    63: "Moderate rain",
-    65: "Heavy rain",
-    66: "Light freezing rain",
-    67: "Heavy freezing rain",
-    71: "Slight snow fall",
-    73: "Moderate snow fall",
-    75: "Heavy snow fall",
-    77: "Snow grains",
-    80: "Slight rain showers",
-    81: "Moderate rain showers",
-    82: "Violent rain showers",
-    85: "Slight snow showers",
-    86: "Heavy snow showers",
-    95: "Thunderstorm",
-    96: "Thunderstorm with slight hail",
-    99: "Thunderstorm with heavy hail",
+DEFAULT_WEATHER_URL = "https://weather.com/en-AU/weather/today/l/-27.61,153.33?par=altinet"
+
+REQUEST_HEADERS = {
+    "User-Agent": (
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+        "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    )
 }
 
 
 @dataclass
 class WeatherSnapshot:
-    """Parsed data returned by the Open-Meteo APIs."""
+    """Parsed weather data scraped from the provider."""
 
     temperature_c: Optional[float] = None
     humidity_percent: Optional[int] = None
@@ -71,112 +49,157 @@ class WeatherSnapshot:
         return fields
 
 
-def _select_hourly_value(hourly: Dict[str, Any], key: str, timestamp: str) -> Optional[Any]:
-    """Return the hourly value for the provided timestamp if it exists."""
+def _coerce_scalar(value: Any) -> Any:
+    """Extract a scalar value from nested structures returned by the site."""
 
-    if not hourly:
+    if isinstance(value, dict):
+        for key in ("value", "values", "min", "max", "amount", "number"):
+            if key in value:
+                result = _coerce_scalar(value[key])
+                if result is not None:
+                    return result
         return None
 
-    times = hourly.get("time") or []
-    values = hourly.get(key) or []
+    if isinstance(value, (list, tuple)):
+        for item in value:
+            result = _coerce_scalar(item)
+            if result is not None:
+                return result
+        return None
+
+    return value
+
+
+def _to_float(value: Any) -> Optional[float]:
+    scalar = _coerce_scalar(value)
+    if scalar is None:
+        return None
     try:
-        index = times.index(timestamp)
-    except ValueError:
+        numeric = float(scalar)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    return numeric
+
+
+def _to_int(value: Any) -> Optional[int]:
+    scalar = _coerce_scalar(value)
+    if scalar is None:
+        return None
+    try:
+        numeric = int(round(float(scalar)))
+    except (TypeError, ValueError):
+        return None
+    return numeric
+
+
+def _extract_next_data(html: str) -> Optional[Dict[str, Any]]:
+    """Extract the Next.js data blob from the rendered HTML."""
+
+    marker = '<script id="__NEXT_DATA__" type="application/json">'
+    start = html.find(marker)
+    if start == -1:
+        return None
+    start += len(marker)
+    end = html.find("</script>", start)
+    if end == -1:
         return None
 
-    if index >= len(values):
+    payload = html[start:end]
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError:
         return None
 
-    return values[index]
+
+def _find_dict_with_keys(data: Any, required: Iterable[str]) -> Optional[Dict[str, Any]]:
+    """Search the nested JSON for a dictionary containing the provided keys."""
+
+    stack = [data]
+    required_set = set(required)
+
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            if required_set.issubset(current.keys()):
+                return current
+            stack.extend(current.values())
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+
+    return None
 
 
-def _parse_weather_summary(code: Optional[int]) -> Optional[str]:
-    if code is None:
-        return None
-    return WEATHER_CODE_SUMMARY.get(code, "Unknown conditions")
+def _find_first_value_for_key(data: Any, key: str) -> Any:
+    """Return the first value encountered for ``key`` in the nested JSON."""
+
+    stack = [data]
+
+    while stack:
+        current = stack.pop()
+        if isinstance(current, dict):
+            if key in current:
+                return current[key]
+            stack.extend(current.values())
+        elif isinstance(current, (list, tuple)):
+            stack.extend(current)
+
+    return None
+
+
+def _coerce_summary(payload: Dict[str, Any]) -> Optional[str]:
+    for key in ("wxPhraseLong", "wxPhraseShort", "phrase", "narrative"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _derive_timezone(data: Dict[str, Any]) -> str:
+    candidate = _find_first_value_for_key(data, "timeZoneId")
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate.strip()
+
+    candidate = _find_first_value_for_key(data, "timeZone")
+    if isinstance(candidate, str) and candidate.strip():
+        return candidate.strip()
+
+    return "Australia/Brisbane"
 
 
 def fetch_weather_snapshot(address: str) -> Dict[str, Any]:
-    """Fetch weather information for the provided address.
+    """Scrape outdoor weather data for Macleay Island in Brisbane."""
 
-    The Open-Meteo API is used because it doesn't require API keys and offers free
-    geocoding as well as weather and air quality data. All errors are swallowed so
-    the dashboard can continue to render even if the external service is
-    unavailable.
-    """
-
-    if not address or not address.strip():
-        return {}
+    del address  # The dashboard always displays Macleay Island conditions.
 
     try:
-        geocode_response = httpx.get(
-            "https://geocoding-api.open-meteo.com/v1/search",
-            params={"name": address, "count": 1},
-            timeout=5.0,
-        )
-        geocode_response.raise_for_status()
-        geocode_data = geocode_response.json()
-        results = geocode_data.get("results")
-        if not results:
-            return {}
-
-        location = results[0]
-        latitude = location.get("latitude")
-        longitude = location.get("longitude")
-        timezone = location.get("timezone") or "auto"
-        if latitude is None or longitude is None:
-            return {}
-
-        weather_response = httpx.get(
-            "https://api.open-meteo.com/v1/forecast",
-            params={
-                "latitude": latitude,
-                "longitude": longitude,
-                "current_weather": "true",
-                "hourly": "relativehumidity_2m",
-                "timezone": timezone,
-            },
-            timeout=5.0,
-        )
-        weather_response.raise_for_status()
-        weather_data = weather_response.json()
-        current_weather = weather_data.get("current_weather") or {}
-        timestamp = current_weather.get("time")
-        hourly = weather_data.get("hourly") or {}
-
-        snapshot = WeatherSnapshot(
-            temperature_c=current_weather.get("temperature"),
-            humidity_percent=_select_hourly_value(hourly, "relativehumidity_2m", timestamp)
-            if timestamp
-            else None,
-            summary=_parse_weather_summary(current_weather.get("weathercode")),
-            wind_speed_kmh=current_weather.get("windspeed"),
-            wind_direction_deg=current_weather.get("winddirection"),
-            timezone_name=location.get("timezone"),
-        )
-
-        air_quality_response = httpx.get(
-            "https://air-quality-api.open-meteo.com/v1/air-quality",
-            params={
-                "latitude": latitude,
-                "longitude": longitude,
-                "hourly": "us_aqi",
-                "timezone": timezone,
-                "past_days": 0,
-                "forecast_days": 1,
-            },
-            timeout=5.0,
-        )
-        air_quality_response.raise_for_status()
-        air_quality_data = air_quality_response.json()
-        aq_hourly = air_quality_data.get("hourly") or {}
-        if timestamp:
-            snapshot.air_quality_index = _select_hourly_value(aq_hourly, "us_aqi", timestamp)
-        else:
-            values = aq_hourly.get("us_aqi") or []
-            snapshot.air_quality_index = values[0] if values else None
-
-        return snapshot.as_environment_fields()
-
-    except (httpx.HTTPError, KeyError, ValueError):
+        response = httpx.get(DEFAULT_WEATHER_URL, headers=REQUEST_HEADERS, timeout=10.0)
+        response.raise_for_status()
+    except httpx.HTTPError:
         return {}
+
+    data = _extract_next_data(response.text)
+    if not data:
+        return {}
+
+    observation = _find_dict_with_keys(
+        data,
+        {"temperature", "relativeHumidity", "windSpeed", "windDirection"},
+    )
+    if not observation:
+        return {}
+
+    snapshot = WeatherSnapshot(
+        temperature_c=_to_float(observation.get("temperature")),
+        humidity_percent=_to_int(observation.get("relativeHumidity")),
+        summary=_coerce_summary(observation),
+        wind_speed_kmh=_to_float(observation.get("windSpeed")),
+        wind_direction_deg=_to_float(observation.get("windDirection")),
+        timezone_name=_derive_timezone(data),
+    )
+
+    air_quality = _find_first_value_for_key(data, "airQualityIndex")
+    snapshot.air_quality_index = _to_int(air_quality)
+
+    return snapshot.as_environment_fields()


### PR DESCRIPTION
## Summary
- scrape live weather for Macleay Island from weather.com and serve it through a dedicated endpoint
- update the home dashboard to include a detailed weather table that refreshes asynchronously
- add styling, frontend logic, and backend tests covering the new weather workflow

## Testing
- pytest backend/web/tests/test_weather.py backend/web/tests/test_views.py

------
https://chatgpt.com/codex/tasks/task_e_68dba992d368832faf4cd3c857d7b402