### PR TITLE
Add annotated room overlays to home viewer

### DIFF
--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -1,4 +1,5 @@
 #home-viewer {
+  position: relative;
   min-height: clamp(520px, 80vh, 960px);
   background: linear-gradient(180deg, #f8f9fb 0%, #e9eef5 100%);
 }
@@ -8,6 +9,8 @@
   width: 100% !important;
   height: 100% !important;
   touch-action: none;
+  position: relative;
+  z-index: 1;
 }
 
 .viewer-shell {
@@ -18,6 +21,84 @@
   position: absolute;
   inset: 0;
   background: rgba(255, 255, 255, 0.85);
+  z-index: 3;
+}
+
+.viewer-annotations {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.viewer-annotations__canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.room-info-card {
+  position: absolute;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0.75rem;
+  box-shadow: 0 12px 30px rgba(15, 28, 45, 0.12);
+  padding: 1rem 1.25rem;
+  width: min(260px, 60vw);
+  color: var(--bs-body-color);
+  pointer-events: auto;
+  transition: opacity 0.2s ease;
+}
+
+.room-info-card--left {
+  transform: translate(-100%, -50%);
+  text-align: right;
+}
+
+.room-info-card--right {
+  transform: translate(0, -50%);
+  text-align: left;
+}
+
+.room-info-card__title {
+  font-size: 1rem;
+  font-weight: 600;
+  margin-bottom: 0.75rem;
+}
+
+.room-info-card__metrics {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem 1rem;
+}
+
+.room-info-card__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.room-info-card__metric dt {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--bs-secondary-color);
+  margin: 0;
+}
+
+.room-info-card__metric dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.95rem;
+  color: var(--bs-body-color);
+}
+
+.room-info-connector {
+  stroke: rgba(0, 0, 0, 0.45);
+  stroke-width: 1.25;
 }
 
 .home-page main.container {


### PR DESCRIPTION
## Summary
- overlay room information cards on the 3D home viewer with connector lines to room centers
- style the viewer shell to layer the annotations beneath the existing loading overlays and match the dashboard aesthetic

## Testing
- python backend/manage.py migrate
- python backend/manage.py runserver 0.0.0.0:8000


------
https://chatgpt.com/codex/tasks/task_e_68dc82476804832fb7c35581a2714632