### PR TITLE
Tighten room overlay layout for home viewer

### DIFF
--- a/backend/web/static/web/css/home.css
+++ b/backend/web/static/web/css/home.css
@@ -1,4 +1,5 @@
 #home-viewer {
+  position: relative;
   min-height: clamp(520px, 80vh, 960px);
   background: linear-gradient(180deg, #f8f9fb 0%, #e9eef5 100%);
 }
@@ -8,6 +9,8 @@
   width: 100% !important;
   height: 100% !important;
   touch-action: none;
+  position: relative;
+  z-index: 1;
 }
 
 .viewer-shell {
@@ -18,6 +21,84 @@
   position: absolute;
   inset: 0;
   background: rgba(255, 255, 255, 0.85);
+  z-index: 3;
+}
+
+.viewer-annotations {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+  z-index: 2;
+}
+
+.viewer-annotations__canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.room-info-card {
+  position: absolute;
+  background: #ffffff;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 0.75rem;
+  box-shadow: 0 12px 30px rgba(15, 28, 45, 0.12);
+  padding: 0.75rem 1rem;
+  width: min(220px, 55vw);
+  color: var(--bs-body-color);
+  pointer-events: auto;
+  transition: opacity 0.2s ease;
+}
+
+.room-info-card--left {
+  transform: translate(-100%, -50%);
+  text-align: right;
+}
+
+.room-info-card--right {
+  transform: translate(0, -50%);
+  text-align: left;
+}
+
+.room-info-card__title {
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 0.5rem;
+}
+
+.room-info-card__metrics {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.375rem 0.75rem;
+}
+
+.room-info-card__metric {
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+
+.room-info-card__metric dt {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--bs-secondary-color);
+  margin: 0;
+}
+
+.room-info-card__metric dd {
+  margin: 0;
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: var(--bs-body-color);
+}
+
+.room-info-connector {
+  stroke: rgba(0, 0, 0, 0.45);
+  stroke-width: 1.25;
 }
 
 .home-page main.container {

--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -42,6 +42,7 @@ function initialiseViewer(containerEl, objUrl) {
   controls.maxPolarAngle = Math.PI / 2.1;
 
   let updateSmoothZoom = () => {};
+  let updateRoomAnnotations = () => {};
 
   const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
   const keyLight = new THREE.DirectionalLight(0xffffff, 0.8);
@@ -65,13 +66,19 @@ function initialiseViewer(containerEl, objUrl) {
 
   loadObjModel(objUrl, { wallMaterial, roofMaterial })
     .then((object) => {
-      const distances = prepareModel(object, scene, controls);
+      const { distances, bounds } = prepareModel(object, scene, controls);
       updateSmoothZoom = setupSmoothScrollZoom(
         controls,
         camera,
         renderer.domElement,
         distances,
       );
+      updateRoomAnnotations = createRoomAnnotations({
+        containerEl,
+        camera,
+        renderer,
+        bounds,
+      });
       animate();
     })
     .catch((error) => {
@@ -89,6 +96,7 @@ function initialiseViewer(containerEl, objUrl) {
   function animate() {
     requestAnimationFrame(animate);
     updateSmoothZoom();
+    updateRoomAnnotations();
     controls.update();
     renderer.render(scene, camera);
   }
@@ -129,7 +137,9 @@ function prepareModel(model, scene, controls) {
   controls.maxDistance = maxDistance;
   controls.update();
 
-  return { minDistance, maxDistance };
+  const adjustedBounds = new THREE.Box3().setFromObject(model);
+
+  return { distances: { minDistance, maxDistance }, bounds: adjustedBounds };
 }
 
 function setupSmoothScrollZoom(controls, camera, domElement, distances) {
@@ -294,6 +304,276 @@ function setupSmoothScrollZoom(controls, camera, domElement, distances) {
     newPosition.copy(direction).multiplyScalar(nextDistance).add(target);
     camera.position.copy(newPosition);
   };
+}
+
+function createRoomAnnotations({ containerEl, camera, renderer, bounds }) {
+  const overlay = document.createElement('div');
+  overlay.className = 'viewer-annotations';
+  containerEl.appendChild(overlay);
+
+  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  svg.classList.add('viewer-annotations__canvas');
+  svg.setAttribute('role', 'presentation');
+  overlay.appendChild(svg);
+
+  const roomDefinitions = [
+    {
+      name: 'Living Room',
+      relativePosition: { x: 0.78, y: 0.15, z: 0.36 },
+      anchor: 'right',
+      metrics: {
+        temperature: '21.5°C',
+        occupants: '2 people',
+        brightness: '340 lux',
+        noise: '38 dBA',
+      },
+    },
+    {
+      name: 'Kitchen',
+      relativePosition: { x: 0.28, y: 0.18, z: 0.35 },
+      anchor: 'left',
+      metrics: {
+        temperature: '23.1°C',
+        occupants: '1 person',
+        brightness: '420 lux',
+        noise: '41 dBA',
+      },
+    },
+    {
+      name: 'Bedroom',
+      relativePosition: { x: 0.32, y: 0.18, z: 0.74 },
+      anchor: 'left',
+      metrics: {
+        temperature: '20.2°C',
+        occupants: '0 people',
+        brightness: '120 lux',
+        noise: '30 dBA',
+      },
+    },
+  ];
+
+  const lerp = THREE.MathUtils.lerp;
+  const toWorldPosition = (relative) => {
+    const x = lerp(bounds.min.x, bounds.max.x, relative.x);
+    const y = lerp(bounds.min.y, bounds.max.y, relative.y ?? 0.5);
+    const z = lerp(bounds.min.z, bounds.max.z, relative.z);
+    return new THREE.Vector3(x, y, z);
+  };
+
+  const renderCard = (room) => {
+    const metrics = room.metrics;
+    return `
+      <h3 class="room-info-card__title">${room.name}</h3>
+      <dl class="room-info-card__metrics">
+        <div class="room-info-card__metric">
+          <dt>Temp</dt>
+          <dd>${metrics.temperature}</dd>
+        </div>
+        <div class="room-info-card__metric">
+          <dt>People</dt>
+          <dd>${metrics.occupants}</dd>
+        </div>
+        <div class="room-info-card__metric">
+          <dt>Brightness</dt>
+          <dd>${metrics.brightness}</dd>
+        </div>
+        <div class="room-info-card__metric">
+          <dt>Ambient noise</dt>
+          <dd>${metrics.noise}</dd>
+        </div>
+      </dl>
+    `;
+  };
+
+  const entries = roomDefinitions.map((room) => {
+    const card = document.createElement('article');
+    card.className = 'room-info-card';
+    card.innerHTML = renderCard(room);
+    overlay.appendChild(card);
+
+    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    line.classList.add('room-info-connector');
+    line.setAttribute('stroke', 'rgba(0, 0, 0, 0.5)');
+    line.setAttribute('stroke-width', '1.25');
+    line.setAttribute('vector-effect', 'non-scaling-stroke');
+    svg.appendChild(line);
+
+    return {
+      room,
+      card,
+      line,
+      worldPosition: toWorldPosition(room.relativePosition),
+    };
+  });
+
+  const rendererSize = new THREE.Vector2();
+  const projectedPosition = new THREE.Vector3();
+
+  const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
+
+  const preventCollisions = (items, containerHeight, margin, spacing) => {
+    const groups = {
+      left: [],
+      right: [],
+    };
+
+    for (const item of items) {
+      groups[item.anchor]?.push(item);
+    }
+
+    const enforceGroup = (group) => {
+      if (group.length === 0) {
+        return;
+      }
+
+      group.sort((a, b) => a.centerY - b.centerY);
+
+      let previous = null;
+      for (const item of group) {
+        const minCenter = margin + item.halfHeight;
+        const maxCenter = containerHeight - margin - item.halfHeight;
+        let center = clamp(item.centerY, minCenter, maxCenter);
+        if (previous) {
+          const minAllowed =
+            previous.centerY + previous.halfHeight + item.halfHeight + spacing;
+          if (center < minAllowed) {
+            center = minAllowed;
+          }
+        }
+        item.centerY = clamp(center, minCenter, maxCenter);
+        previous = item;
+      }
+
+      let next = null;
+      for (let index = group.length - 1; index >= 0; index -= 1) {
+        const item = group[index];
+        const minCenter = margin + item.halfHeight;
+        const maxCenter = containerHeight - margin - item.halfHeight;
+        let center = clamp(item.centerY, minCenter, maxCenter);
+        if (next) {
+          const maxAllowed =
+            next.centerY - (next.halfHeight + item.halfHeight + spacing);
+          if (center > maxAllowed) {
+            center = maxAllowed;
+          }
+        }
+        item.centerY = clamp(center, minCenter, maxCenter);
+        next = item;
+      }
+
+      previous = null;
+      for (const item of group) {
+        const minCenter = margin + item.halfHeight;
+        const maxCenter = containerHeight - margin - item.halfHeight;
+        let center = clamp(item.centerY, minCenter, maxCenter);
+        if (previous) {
+          const minAllowed =
+            previous.centerY + previous.halfHeight + item.halfHeight + spacing;
+          if (center < minAllowed) {
+            center = minAllowed;
+          }
+        }
+        item.centerY = clamp(center, minCenter, maxCenter);
+        previous = item;
+      }
+    };
+
+    enforceGroup(groups.left);
+    enforceGroup(groups.right);
+  };
+
+  const update = () => {
+    renderer.getSize(rendererSize);
+    const width = rendererSize.x;
+    const height = rendererSize.y;
+
+    overlay.style.width = `${width}px`;
+    overlay.style.height = `${height}px`;
+    svg.setAttribute('width', `${width}`);
+    svg.setAttribute('height', `${height}`);
+    svg.setAttribute('viewBox', `0 0 ${width} ${height}`);
+
+    const margin = 12;
+    const spacing = 12;
+    const defaultHorizontalOffset = 140;
+
+    const layoutEntries = [];
+
+    for (const entry of entries) {
+      projectedPosition.copy(entry.worldPosition).project(camera);
+
+      const visible =
+        projectedPosition.z > -1 &&
+        projectedPosition.z < 1 &&
+        Math.abs(projectedPosition.x) <= 1.2 &&
+        Math.abs(projectedPosition.y) <= 1.2;
+
+      if (!visible) {
+        entry.card.style.opacity = '0';
+        entry.card.style.pointerEvents = 'none';
+        entry.line.setAttribute('opacity', '0');
+        continue;
+      }
+
+      entry.card.style.opacity = '';
+      entry.card.style.pointerEvents = '';
+      entry.line.setAttribute('opacity', '1');
+
+      const anchor = entry.room.anchor ?? (projectedPosition.x < 0 ? 'left' : 'right');
+      entry.card.classList.toggle('room-info-card--left', anchor === 'left');
+      entry.card.classList.toggle('room-info-card--right', anchor === 'right');
+
+      const x = (projectedPosition.x * 0.5 + 0.5) * width;
+      const y = (-projectedPosition.y * 0.5 + 0.5) * height;
+
+      const cardWidth = entry.card.offsetWidth || 180;
+      const cardHeight = entry.card.offsetHeight || 120;
+      const halfHeight = cardHeight / 2;
+
+      const verticalOffset = entry.room.verticalOffset ?? 0;
+      let connectionY = y + verticalOffset;
+      let connectionX =
+        anchor === 'right'
+          ? x + (entry.room.horizontalOffset ?? defaultHorizontalOffset)
+          : x - (entry.room.horizontalOffset ?? defaultHorizontalOffset);
+
+      if (anchor === 'right') {
+        connectionX = clamp(connectionX, margin, width - margin - cardWidth);
+      } else {
+        connectionX = clamp(connectionX, margin + cardWidth, width - margin);
+      }
+
+      layoutEntries.push({
+        entry,
+        anchor,
+        connectionX,
+        centerY: clamp(
+          connectionY,
+          margin + halfHeight,
+          height - margin - halfHeight,
+        ),
+        halfHeight,
+      });
+
+      entry.line.setAttribute('x1', `${x}`);
+      entry.line.setAttribute('y1', `${y}`);
+    }
+
+    preventCollisions(layoutEntries, height, margin, spacing);
+
+    for (const layout of layoutEntries) {
+      const { entry, connectionX, centerY } = layout;
+
+      entry.card.style.left = `${connectionX}px`;
+      entry.card.style.top = `${centerY}px`;
+
+      entry.line.setAttribute('x2', `${connectionX}`);
+      entry.line.setAttribute('y2', `${centerY}`);
+    }
+  };
+
+  update();
+  return update;
 }
 
 async function loadObjModel(url, materials) {


### PR DESCRIPTION
## Summary
- overlay room information cards on the 3D home viewer with connector lines to room centers
- style the viewer shell to layer the annotations beneath the existing loading overlays and match the dashboard aesthetic
- shrink room info cards and add collision handling so annotations stay compact and avoid overlapping

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68dc82476804832fb7c35581a2714632