### PR TITLE
Ensure training and test cameras don't conflict

### DIFF
--- a/backend/web/static/web/js/training.js
+++ b/backend/web/static/web/js/training.js
@@ -199,6 +199,8 @@ if (container) {
       return;
     }
 
+    stopTestCamera();
+
     if (mediaStream) {
       return;
     }
@@ -230,6 +232,8 @@ if (container) {
       setTestStatus("Camera access is not supported in this browser.", true);
       return;
     }
+
+    stopCamera();
 
     if (testStream) {
       return;


### PR DESCRIPTION
## Summary
- stop any active test camera stream before opening the training camera
- stop the training camera stream before opening the test camera

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68df701c77e4832f8a8cc196ef657d3d