### PR TITLE
Add backend face testing service

### DIFF
--- a/backend/web/services/face_training.py
+++ b/backend/web/services/face_training.py
@@ -1,0 +1,251 @@
+"""Utilities for evaluating captured training images against known faces."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import io
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+import numpy as np
+
+try:  # pragma: no cover - optional dependency for runtime recognition
+    from PIL import Image
+except ImportError:  # pragma: no cover - handled gracefully at runtime
+    Image = None  # type: ignore
+
+from ..models import TrainingImage, TrainingProfile
+
+_FACE_ANALYZER: Optional[object] = None
+_TRAINING_EMBEDDING_CACHE: Dict[int, np.ndarray] = {}
+
+
+@dataclass(frozen=True)
+class TrainingTestResult:
+    """Represents the outcome of a face matching request."""
+
+    payload: dict
+    status: int
+
+
+def clean_image_data_uri(data_uri: str) -> str | None:
+    """Validate that a provided data URI contains base64 encoded image data."""
+
+    if not isinstance(data_uri, str):
+        return None
+
+    candidate = data_uri.strip()
+    if not candidate.startswith("data:image/"):
+        return None
+
+    header, _, base64_data = candidate.partition(",")
+    if not base64_data:
+        return None
+
+    if ";base64" not in header.lower():
+        return None
+
+    try:
+        base64.b64decode(base64_data, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+    return f"{header},{base64_data}"
+
+
+def reset_training_embedding_cache() -> None:
+    """Clear cached embeddings so new training data is picked up."""
+
+    _TRAINING_EMBEDDING_CACHE.clear()
+
+
+def load_image_from_data_uri(data_uri: str) -> Optional[np.ndarray]:
+    """Decode a base64 image data URI into an RGB numpy array."""
+
+    if Image is None:
+        return None
+
+    cleaned = clean_image_data_uri(data_uri)
+    if not cleaned:
+        return None
+
+    _, _, base64_data = cleaned.partition(",")
+    try:
+        raw_bytes = base64.b64decode(base64_data, validate=True)
+    except (binascii.Error, ValueError):
+        return None
+
+    try:
+        with Image.open(io.BytesIO(raw_bytes)) as image:  # type: ignore[union-attr]
+            rgb_image = image.convert("RGB")
+            return np.array(rgb_image)
+    except Exception:  # pragma: no cover - Pillow failures are handled gracefully
+        return None
+
+
+def get_face_analyzer() -> Optional[object]:
+    """Return a cached instance of the InsightFace analysis helper."""
+
+    global _FACE_ANALYZER
+    if _FACE_ANALYZER is not None:
+        return _FACE_ANALYZER
+
+    try:
+        from insightface.app import FaceAnalysis  # type: ignore
+    except Exception:  # pragma: no cover - optional dependency unavailable
+        return None
+
+    try:
+        analyzer = FaceAnalysis(name="buffalo_l")
+        analyzer.prepare(ctx_id=-1, det_size=(640, 640))
+    except Exception:  # pragma: no cover - runtime initialisation failure
+        return None
+
+    _FACE_ANALYZER = analyzer
+    return _FACE_ANALYZER
+
+
+def extract_embedding(analyzer: object, image: np.ndarray) -> Optional[np.ndarray]:
+    """Generate a normalised embedding for ``image`` using ``analyzer``."""
+
+    if analyzer is None:
+        return None
+
+    try:
+        faces = analyzer.get(image)  # type: ignore[attr-defined]
+    except Exception:
+        return None
+
+    if not faces:
+        return None
+
+    face = faces[0]
+    embedding = getattr(face, "normed_embedding", None)
+    if embedding is None:
+        return None
+
+    array = np.asarray(embedding, dtype=np.float32)
+    if array.size == 0:
+        return None
+
+    norm = np.linalg.norm(array)
+    if norm == 0:
+        return None
+    return array / norm
+
+
+def embedding_for_training_image(
+    analyzer: object, image: TrainingImage
+) -> Optional[np.ndarray]:
+    """Return a cached embedding vector for ``image``."""
+
+    cached = _TRAINING_EMBEDDING_CACHE.get(image.pk)
+    if cached is not None:
+        return cached
+
+    array = load_image_from_data_uri(image.image_data)
+    if array is None:
+        return None
+
+    embedding = extract_embedding(analyzer, array)
+    if embedding is None:
+        return None
+
+    _TRAINING_EMBEDDING_CACHE[image.pk] = embedding
+    return embedding
+
+
+def evaluate_face_test(image_data: str | None) -> TrainingTestResult:
+    """Evaluate ``image_data`` against known training profiles."""
+
+    analyzer = get_face_analyzer()
+    if analyzer is None or Image is None:
+        return TrainingTestResult(
+            {
+                "success": False,
+                "error": "Face recognition components are unavailable on this server.",
+            },
+            status=503,
+        )
+
+    cleaned_image = clean_image_data_uri(image_data) if image_data else None
+    if not cleaned_image:
+        return TrainingTestResult(
+            {"success": False, "error": "Provide a valid captured image."},
+            status=400,
+        )
+
+    probe_image = load_image_from_data_uri(cleaned_image)
+    if probe_image is None:
+        return TrainingTestResult(
+            {
+                "success": False,
+                "error": "Unable to decode the captured frame for analysis.",
+            },
+            status=400,
+        )
+
+    probe_embedding = extract_embedding(analyzer, probe_image)
+    if probe_embedding is None:
+        return TrainingTestResult(
+            {
+                "success": False,
+                "error": "No face was detected in the captured frame.",
+            },
+            status=422,
+        )
+
+    profiles = TrainingProfile.objects.prefetch_related("images").all()
+    if not profiles:
+        return TrainingTestResult(
+            {
+                "success": False,
+                "error": "No trained profiles are available yet.",
+            },
+            status=404,
+        )
+
+    best_profile: Optional[TrainingProfile] = None
+    best_score: float = -1.0
+
+    for profile in profiles:
+        for training_image in profile.images.all():
+            embedding = embedding_for_training_image(analyzer, training_image)
+            if embedding is None:
+                continue
+            score = float(np.dot(probe_embedding, embedding))
+            if score > best_score:
+                best_score = score
+                best_profile = profile
+
+    threshold = 0.35
+    confidence = float(min(max(best_score, 0.0), 1.0))
+
+    if best_profile is None or best_score < threshold:
+        return TrainingTestResult(
+            {
+                "success": True,
+                "match": None,
+                "confidence": round(confidence, 3),
+                "message": "No trained faces matched the capture.",
+            },
+            status=200,
+        )
+
+    return TrainingTestResult(
+        {
+            "success": True,
+            "confidence": round(confidence, 3),
+            "match": {
+                "id": best_profile.id,
+                "full_name": best_profile.full_name,
+                "image_count": best_profile.image_count,
+                "trained_at": best_profile.trained_at.isoformat()
+                if best_profile.trained_at
+                else None,
+            },
+            "message": f"Match found: {best_profile.full_name}.",
+        },
+        status=200,
+    )

--- a/backend/web/tests/test_views.py
+++ b/backend/web/tests/test_views.py
@@ -207,7 +207,7 @@ def test_training_test_requires_face_components(
     user = User.objects.create_user(username="tester", password="password123")
     client.force_login(user)
 
-    monkeypatch.setattr("web.views._get_face_analyzer", lambda: None)
+    monkeypatch.setattr("web.services.face_training.get_face_analyzer", lambda: None)
 
     response = client.post(
         reverse("web:training-test"),
@@ -235,13 +235,13 @@ def test_training_test_returns_match(
         "data:image/png;base64,cHJvYmU=": np.array([1.0, 0.0], dtype=float),
     }
 
-    monkeypatch.setattr("web.views._get_face_analyzer", lambda: object())
-    monkeypatch.setattr("web.views._load_image_from_data_uri", lambda data: data)
+    monkeypatch.setattr("web.services.face_training.get_face_analyzer", lambda: object())
+    monkeypatch.setattr("web.services.face_training.load_image_from_data_uri", lambda data: data)
     monkeypatch.setattr(
-        "web.views._extract_embedding", lambda analyzer, image: embeddings.get(image)
+        "web.services.face_training.extract_embedding", lambda analyzer, image: embeddings.get(image)
     )
     monkeypatch.setattr(
-        "web.views._embedding_for_training_image",
+        "web.services.face_training.embedding_for_training_image",
         lambda analyzer, image: embeddings.get(image.image_data),
     )
 
@@ -275,13 +275,13 @@ def test_training_test_handles_no_match(
         "data:image/png;base64,cHJvYmU=": np.array([1.0, 0.0], dtype=float),
     }
 
-    monkeypatch.setattr("web.views._get_face_analyzer", lambda: object())
-    monkeypatch.setattr("web.views._load_image_from_data_uri", lambda data: data)
+    monkeypatch.setattr("web.services.face_training.get_face_analyzer", lambda: object())
+    monkeypatch.setattr("web.services.face_training.load_image_from_data_uri", lambda data: data)
     monkeypatch.setattr(
-        "web.views._extract_embedding", lambda analyzer, image: embeddings.get(image)
+        "web.services.face_training.extract_embedding", lambda analyzer, image: embeddings.get(image)
     )
     monkeypatch.setattr(
-        "web.views._embedding_for_training_image",
+        "web.services.face_training.embedding_for_training_image",
         lambda analyzer, image: embeddings.get(image.image_data),
     )
 

--- a/backend/web/views.py
+++ b/backend/web/views.py
@@ -1,11 +1,6 @@
 from __future__ import annotations
 
-import base64
-import base64
-import binascii
-import io
 import json
-from typing import Dict, Optional
 
 from django.conf import settings
 from django.contrib import messages
@@ -16,15 +11,14 @@ from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 
-import numpy as np
-
-try:  # pragma: no cover - optional dependency for runtime recognition
-    from PIL import Image
-except ImportError:  # pragma: no cover - handled gracefully at runtime
-    Image = None  # type: ignore
-
 from .forms import SystemSettingsForm, UserSettingsForm
 from .models import SystemSettings, TrainingImage, TrainingProfile
+from .services.face_training import (
+    TrainingTestResult,
+    clean_image_data_uri,
+    evaluate_face_test,
+    reset_training_embedding_cache,
+)
 from .weather import fetch_weather_snapshot
 
 
@@ -196,135 +190,6 @@ def weather_snapshot(request):
     return JsonResponse({"success": False}, status=503)
 
 
-def _clean_image_data_uri(data_uri: str) -> str | None:
-    """Validate that a provided data URI contains base64 encoded image data."""
-
-    if not isinstance(data_uri, str):
-        return None
-
-    candidate = data_uri.strip()
-    if not candidate.startswith("data:image/"):
-        return None
-
-    header, _, base64_data = candidate.partition(",")
-    if not base64_data:
-        return None
-
-    if ";base64" not in header.lower():
-        return None
-
-    try:
-        base64.b64decode(base64_data, validate=True)
-    except (binascii.Error, ValueError):
-        return None
-
-    return f"{header},{base64_data}"
-
-
-_FACE_ANALYZER: Optional[object] = None
-_TRAINING_EMBEDDING_CACHE: Dict[int, np.ndarray] = {}
-
-
-def _reset_training_embedding_cache() -> None:
-    """Clear cached embeddings so new training data is picked up."""
-
-    _TRAINING_EMBEDDING_CACHE.clear()
-
-
-def _load_image_from_data_uri(data_uri: str) -> Optional[np.ndarray]:
-    """Decode a base64 image data URI into an RGB numpy array."""
-
-    if Image is None:
-        return None
-
-    cleaned = _clean_image_data_uri(data_uri)
-    if not cleaned:
-        return None
-
-    _, _, base64_data = cleaned.partition(",")
-    try:
-        raw_bytes = base64.b64decode(base64_data, validate=True)
-    except (binascii.Error, ValueError):
-        return None
-
-    try:
-        with Image.open(io.BytesIO(raw_bytes)) as image:  # type: ignore[union-attr]
-            rgb_image = image.convert("RGB")
-            return np.array(rgb_image)
-    except Exception:
-        return None
-
-
-def _get_face_analyzer() -> Optional[object]:
-    """Return a cached instance of the InsightFace analysis helper."""
-
-    global _FACE_ANALYZER
-    if _FACE_ANALYZER is not None:
-        return _FACE_ANALYZER
-
-    try:
-        from insightface.app import FaceAnalysis  # type: ignore
-    except Exception:  # pragma: no cover - optional dependency unavailable
-        return None
-
-    try:
-        analyzer = FaceAnalysis(name="buffalo_l")
-        analyzer.prepare(ctx_id=-1, det_size=(640, 640))
-    except Exception:
-        return None
-
-    _FACE_ANALYZER = analyzer
-    return _FACE_ANALYZER
-
-
-def _extract_embedding(analyzer: object, image: np.ndarray) -> Optional[np.ndarray]:
-    """Generate a normalised embedding for ``image`` using ``analyzer``."""
-
-    if analyzer is None:
-        return None
-
-    try:
-        faces = analyzer.get(image)  # type: ignore[attr-defined]
-    except Exception:
-        return None
-
-    if not faces:
-        return None
-
-    face = faces[0]
-    embedding = getattr(face, "normed_embedding", None)
-    if embedding is None:
-        return None
-
-    array = np.asarray(embedding, dtype=np.float32)
-    if array.size == 0:
-        return None
-
-    norm = np.linalg.norm(array)
-    if norm == 0:
-        return None
-    return array / norm
-
-
-def _embedding_for_training_image(analyzer: object, image: TrainingImage) -> Optional[np.ndarray]:
-    """Return a cached embedding vector for ``image``."""
-
-    cached = _TRAINING_EMBEDDING_CACHE.get(image.pk)
-    if cached is not None:
-        return cached
-
-    array = _load_image_from_data_uri(image.image_data)
-    if array is None:
-        return None
-
-    embedding = _extract_embedding(analyzer, array)
-    if embedding is None:
-        return None
-
-    _TRAINING_EMBEDDING_CACHE[image.pk] = embedding
-    return embedding
-
-
 @login_required
 def training(request):
     """Render the training workspace for capturing and enrolling faces."""
@@ -375,7 +240,7 @@ def training_create(request):
 
     cleaned_images: list[str] = []
     for data_uri in raw_images:
-        cleaned = _clean_image_data_uri(data_uri)
+        cleaned = clean_image_data_uri(data_uri)
         if cleaned:
             cleaned_images.append(cleaned)
 
@@ -402,7 +267,7 @@ def training_create(request):
     )
 
     profile.mark_trained()
-    _reset_training_embedding_cache()
+    reset_training_embedding_cache()
 
     return JsonResponse(
         {
@@ -424,99 +289,14 @@ def training_create(request):
 def training_test(request):
     """Evaluate a captured frame against trained profiles."""
 
-    analyzer = _get_face_analyzer()
-    if analyzer is None or Image is None:
-        return JsonResponse(
-            {
-                "success": False,
-                "error": "Face recognition components are unavailable on this server.",
-            },
-            status=503,
-        )
-
     try:
         payload = json.loads(request.body.decode("utf-8"))
     except (json.JSONDecodeError, UnicodeDecodeError):
         return JsonResponse({"success": False, "error": "Invalid JSON payload."}, status=400)
 
     raw_image = payload.get("image")
-    cleaned_image = _clean_image_data_uri(raw_image)
-    if not cleaned_image:
-        return JsonResponse(
-            {"success": False, "error": "Provide a valid captured image."}, status=400
-        )
-
-    probe_image = _load_image_from_data_uri(cleaned_image)
-    if probe_image is None:
-        return JsonResponse(
-            {
-                "success": False,
-                "error": "Unable to decode the captured frame for analysis.",
-            },
-            status=400,
-        )
-
-    probe_embedding = _extract_embedding(analyzer, probe_image)
-    if probe_embedding is None:
-        return JsonResponse(
-            {
-                "success": False,
-                "error": "No face was detected in the captured frame.",
-            },
-            status=422,
-        )
-
-    profiles = TrainingProfile.objects.prefetch_related("images").all()
-    if not profiles:
-        return JsonResponse(
-            {
-                "success": False,
-                "error": "No trained profiles are available yet.",
-            },
-            status=404,
-        )
-
-    best_profile: Optional[TrainingProfile] = None
-    best_score: float = -1.0
-
-    for profile in profiles:
-        for training_image in profile.images.all():
-            embedding = _embedding_for_training_image(analyzer, training_image)
-            if embedding is None:
-                continue
-            score = float(np.dot(probe_embedding, embedding))
-            if score > best_score:
-                best_score = score
-                best_profile = profile
-
-    threshold = 0.35
-    confidence = float(min(max(best_score, 0.0), 1.0))
-
-    if best_profile is None or best_score < threshold:
-        return JsonResponse(
-            {
-                "success": True,
-                "match": None,
-                "confidence": round(confidence, 3),
-                "message": "No trained faces matched the capture.",
-            }
-        )
-
-    return JsonResponse(
-        {
-            "success": True,
-            "confidence": round(confidence, 3),
-            "match": {
-                "id": best_profile.id,
-                "full_name": best_profile.full_name,
-                "image_count": best_profile.image_count,
-                "trained_at": best_profile.trained_at.isoformat()
-                if best_profile.trained_at
-                else None,
-            },
-            "message": f"Match found: {best_profile.full_name}.",
-        }
-    )
+    result: TrainingTestResult = evaluate_face_test(raw_image)
+    return JsonResponse(result.payload, status=result.status)
 
 
 @login_required


### PR DESCRIPTION
## Summary
- add a dedicated `face_training` service that validates captured images, extracts embeddings, and compares them against trained profiles
- update the training endpoints to consume the new service and keep the embedding cache in sync
- adjust the training tests to patch the new service helpers when simulating recognition flows

## Testing
- pytest backend/web/tests/test_views.py::test_training_test_returns_match backend/web/tests/test_views.py::test_training_test_handles_no_match backend/web/tests/test_views.py::test_training_test_requires_face_components

------
https://chatgpt.com/codex/tasks/task_e_68df881068dc832fa75982a25197a78d