### PR TITLE
Display face match identity after training test

### DIFF
--- a/backend/templates/web/training.html
+++ b/backend/templates/web/training.html
@@ -95,6 +95,9 @@
               <div data-test-result hidden>
                 <div class="alert alert-info mb-0" data-test-result-message></div>
               </div>
+              <div class="mt-2" data-test-identity hidden>
+                <span class="fw-semibold" data-test-identity-name></span>
+              </div>
             </div>
           </div>
 

--- a/backend/web/static/web/js/training.js
+++ b/backend/web/static/web/js/training.js
@@ -21,6 +21,8 @@ if (container) {
   const testStatusElement = form?.querySelector('[data-test-status]');
   const testResultContainer = form?.querySelector('[data-test-result]');
   const testResultMessage = form?.querySelector('[data-test-result-message]');
+  const testIdentityContainer = form?.querySelector('[data-test-identity]');
+  const testIdentityName = form?.querySelector('[data-test-identity-name]');
 
   /** @type {{ dataUrl: string; selected: boolean }} */
   const captures = [];
@@ -89,6 +91,19 @@ if (container) {
     testResultContainer.toggleAttribute("hidden", !message);
     testResultMessage.textContent = message || "";
     testResultMessage.className = `alert alert-${variant} mb-0`;
+  };
+
+  const showIdentity = (name) => {
+    if (!testIdentityContainer || !testIdentityName) {
+      return;
+    }
+    if (name) {
+      testIdentityName.textContent = name;
+      testIdentityContainer.removeAttribute("hidden");
+    } else {
+      testIdentityName.textContent = "";
+      testIdentityContainer.setAttribute("hidden", "hidden");
+    }
   };
 
   const stopCamera = () => {
@@ -435,6 +450,7 @@ if (container) {
         : "Checking the selected capture for trained faces…",
     );
     showTestResult("");
+    showIdentity("");
 
     try {
       const response = await fetch(testingEndpoint, {
@@ -467,6 +483,7 @@ if (container) {
         setTestStatus(
           `Detected ${name} with confidence ${confidence.toFixed(2)}.`,
         );
+        showIdentity(name);
       } else {
         showTestResult(
           `${data.message || "No trained faces matched."} Confidence ${confidence.toFixed(2)}.`,
@@ -476,11 +493,13 @@ if (container) {
           data.message ||
             "A face was detected, but no trained profile matched.",
         );
+        showIdentity("");
       }
     } catch (error) {
       console.error("Testing request failed", error);
       showTestResult(error.message || "Unable to test the capture.", "danger");
       setTestStatus(error.message || "Unable to test the capture.", true);
+      showIdentity("");
     } finally {
       testBusy = false;
       updateButtons();


### PR DESCRIPTION
## Summary
- show the recognised identity beneath the face testing controls in the training workspace
- update the training JavaScript to surface the returned match name and clear it when no match is available

## Testing
- pytest backend/web/tests/test_views.py -k "training_test" -q

------
https://chatgpt.com/codex/tasks/task_e_68df9c80e1b8832fab71b6fd0e245a12