### PR TITLE
Fix undefined connectionY in home viewer annotations

### DIFF
--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -555,6 +555,7 @@ function createRoomAnnotations({ containerEl, camera, renderer, bounds }) {
           height - margin - halfHeight,
         ),
         halfHeight,
+        lineStart: { x, y },
       });
 
       entry.line.setAttribute('x1', `${x}`);
@@ -564,22 +565,15 @@ function createRoomAnnotations({ containerEl, camera, renderer, bounds }) {
     preventCollisions(layoutEntries, height, margin, spacing);
 
     for (const layout of layoutEntries) {
-      const { entry, connectionX, centerY } = layout;
+      const { entry, connectionX, centerY, lineStart } = layout;
 
       entry.card.style.left = `${connectionX}px`;
       entry.card.style.top = `${centerY}px`;
 
+      entry.line.setAttribute('x1', `${lineStart.x}`);
+      entry.line.setAttribute('y1', `${lineStart.y}`);
       entry.line.setAttribute('x2', `${connectionX}`);
       entry.line.setAttribute('y2', `${centerY}`);
-
-      entry.card.style.left = `${connectionX}px`;
-      entry.card.style.top = `${connectionY}px`;
-
-      entry.line.setAttribute('x1', `${x}`);
-      entry.line.setAttribute('y1', `${y}`);
-      entry.line.setAttribute('x2', `${connectionX}`);
-      entry.line.setAttribute('y2', `${connectionY}`);
-
     }
   };
 


### PR DESCRIPTION
## Summary
- retain layout data for room annotation lines when computing collision-free positions
- remove duplicated DOM updates that referenced an undefined connectionY value

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfa2892384832fa5c21ce6c29e49eb