### PR TITLE
Fix Three.js duplication and provide weather fallback data

### DIFF
--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -1,5 +1,5 @@
-import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js?module';
-import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js?module';
+import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
 
 const container = document.getElementById('home-viewer');
 if (!container) {
@@ -537,7 +537,7 @@ function createRoomAnnotations({ containerEl, camera, renderer, bounds }) {
         margin + halfHeight,
         height - margin - halfHeight,
       );
-      const connectionY = clampedCenterY;
+      const connectionYPosition = clampedCenterY;
       let connectionX =
         anchor === 'right'
           ? x + (entry.room.horizontalOffset ?? defaultHorizontalOffset)
@@ -554,14 +554,14 @@ function createRoomAnnotations({ containerEl, camera, renderer, bounds }) {
         entry,
         anchor,
         connectionX,
-        connectionY,
+        connectionY: connectionYPosition,
         halfHeight,
         lineStart: { x, y },
       });
 
       entry.line.setAttribute('x1', `${x}`);
       entry.line.setAttribute('y1', `${y}`);
-      entry.line.setAttribute('y2', `${connectionY}`);
+      entry.line.setAttribute('y2', `${connectionYPosition}`);
     }
 
     preventCollisions(layoutEntries, height, margin, spacing);

--- a/backend/web/tests/test_views.py
+++ b/backend/web/tests/test_views.py
@@ -55,6 +55,7 @@ def test_weather_snapshot_endpoint_returns_data(
     assert response.status_code == 200
     payload = response.json()
     assert payload["success"] is True
+    assert payload["source"] == "live"
     assert payload["data"]["wind_direction_cardinal"] == "S"
     assert payload["data"]["wind_direction_deg"] == 180
 
@@ -69,7 +70,11 @@ def test_weather_snapshot_endpoint_handles_empty_payload(
 
     response = client.get(reverse("web:weather-snapshot"))
 
-    assert response.status_code == 503
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["success"] is True
+    assert payload["source"] == "fallback"
+    assert payload["data"]["weather_summary"] == "Partly cloudy"
 
 
 def test_settings_requires_authentication(client: Client) -> None:

--- a/backend/web/weather.py
+++ b/backend/web/weather.py
@@ -18,6 +18,22 @@ REQUEST_HEADERS = {
     )
 }
 
+FALLBACK_WEATHER_SNAPSHOT: Dict[str, Any] = {
+    "outside_temperature_c": 23.5,
+    "outside_humidity": 64,
+    "weather_summary": "Partly cloudy",
+    "wind_speed_kmh": 13.0,
+    "wind_direction_deg": 135,
+    "air_quality_index": 42,
+    "location_timezone": "Australia/Brisbane",
+}
+
+
+def default_weather_snapshot() -> Dict[str, Any]:
+    """Return a representative weather payload when live data is unavailable."""
+
+    return dict(FALLBACK_WEATHER_SNAPSHOT)
+
 
 @dataclass
 class WeatherSnapshot:


### PR DESCRIPTION
## Summary
- update the home viewer to load a single Three.js instance and resolve the annotation connector reference error
- serve a fallback weather snapshot when the upstream scrape fails and expose the data source in the API response
- adjust the dashboard weather widget to surface fallback status messaging gracefully

## Testing
- pytest backend/web/tests/test_views.py

------
https://chatgpt.com/codex/tasks/task_e_68dfab4dfa60832fab5a34ea4fe5ad21