### PR TITLE
fix: load OrbitControls via module-compatible CDN

### DIFF
--- a/backend/web/static/web/js/home-viewer.js
+++ b/backend/web/static/web/js/home-viewer.js
@@ -1,5 +1,5 @@
 import * as THREE from 'https://unpkg.com/three@0.160.0/build/three.module.js';
-import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js';
+import { OrbitControls } from 'https://unpkg.com/three@0.160.0/examples/jsm/controls/OrbitControls.js?module';
 
 const container = document.getElementById('home-viewer');
 if (!container) {


### PR DESCRIPTION
## Summary
- update the OrbitControls import to request the module-compatible variant from the CDN so it resolves correctly when bundled with native ES modules

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfbfe5bb78832f879fb6380a580480