### PR TITLE
Add python3-empy dependency to interface package

### DIFF
--- a/ros2_ws/src/altinet_interfaces/package.xml
+++ b/ros2_ws/src/altinet_interfaces/package.xml
@@ -9,9 +9,11 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_depend>rosidl_default_generators</build_depend>
+  <build_depend>python3-empy</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
+  <exec_depend>python3-empy</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
## Summary
- add python3-empy as a build and exec dependency for the altinet_interfaces package to ensure template generation support

## Testing
- `rosdep install --from-paths ros2_ws/src --ignore-src` *(fails: rosdep not available in environment)*
- `colcon build` *(fails: colcon not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d2f762e4832fb59a449e753d097d