### PR TITLE
Add Empy dependency to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ Pillow>=10.0
 onnxruntime>=1.16
 insightface>=0.7
 faiss-cpu>=1.7
+empy>=3.3.2
 Django>=4.2,<5.0
 djangorestframework>=3.14
 django-filter>=23.5


### PR DESCRIPTION
## Summary
- add the Empy package to the Python requirements list so it is installed with the rest of the dependencies

## Testing
- `source .venv/bin/activate && pip install -r requirements.txt` *(fails: proxy returned 403 Forbidden for PyPI requests)*
- `colcon build` *(fails: colcon command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1d4612a80832fb9c293db0b895e35