### PR TITLE
Add lark dependency to altinet interfaces package

### DIFF
--- a/ros2_ws/src/altinet_interfaces/package.xml
+++ b/ros2_ws/src/altinet_interfaces/package.xml
@@ -10,10 +10,12 @@
 
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>python3-empy</build_depend>
+  <build_depend>python3-lark-parser</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>python3-empy</exec_depend>
+  <exec_depend>python3-lark-parser</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
## Summary
- declare python3-lark-parser as a build and exec dependency for altinet_interfaces

## Testing
- rosdep install --from-paths ros2_ws/src --ignore-src -r *(fails: command not found)*
- colcon build --base-paths ros2_ws *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e82fa3c8832f9e9b2cc9fc1cdf85