### PR TITLE
Update altinet_interfaces lark dependency

### DIFF
--- a/ros2_ws/src/altinet_interfaces/package.xml
+++ b/ros2_ws/src/altinet_interfaces/package.xml
@@ -10,12 +10,12 @@
 
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>python3-empy</build_depend>
-  <build_depend>python3-lark</build_depend>
+  <build_depend>python3-lark-parser</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>python3-empy</exec_depend>
-  <exec_depend>python3-lark</exec_depend>
+  <exec_depend>python3-lark-parser</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
## Summary
- replace the altinet_interfaces package dependency entries for python3-lark with python3-lark-parser to match the available ROS package name

## Testing
- rosdep install --from-paths src --ignore-src -y *(fails: rosdep command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f368621c832fa4d72c08d663669e