### PR TITLE
Update ROS Lark dependency for Noble compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,13 @@ Django backend for dashboards and historical analysis.
    The UI is served from Django and is available at
    http://127.0.0.1:8000/ with the admin at http://127.0.0.1:8000/admin/.
 
-3. Build the ROS 2 workspace (requires ROS 2 Foxy/Humble and `colcon`):
+3. Build the ROS 2 workspace (requires ROS 2 Foxy/Humble and `colcon`).
+   Install ROS package dependencies (including `python3-lark`) with `rosdep`
+   before invoking `colcon build`:
 
    ```bash
    cd ros2_ws
+   rosdep install --from-paths src --ignore-src -r -y
    colcon build
    source install/setup.bash
    ```

--- a/ros2_ws/src/altinet_interfaces/package.xml
+++ b/ros2_ws/src/altinet_interfaces/package.xml
@@ -10,12 +10,12 @@
 
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>python3-empy</build_depend>
-  <build_depend>python3-lark-parser</build_depend>
+  <build_depend>python3-lark</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>python3-empy</exec_depend>
-  <exec_depend>python3-lark-parser</exec_depend>
+  <exec_depend>python3-lark</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
## Summary
- replace the python3-lark-parser dependency with python3-lark so rosdep resolves on Ubuntu Noble while remaining compatible with Humble
- document the rosdep installation step in the ROS workspace build instructions so developers install python3-lark before building

## Testing
- colcon build *(fails: command not found because ROS 2 tooling is not installed in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f551ab30832f97f4b3451ccefbf6