### PR TITLE
Fix rosdep key for lark dependency

### DIFF
--- a/ros2_ws/src/altinet_interfaces/package.xml
+++ b/ros2_ws/src/altinet_interfaces/package.xml
@@ -10,12 +10,12 @@
 
   <build_depend>rosidl_default_generators</build_depend>
   <build_depend>python3-empy</build_depend>
-  <build_depend>python3-lark</build_depend>
+  <build_depend>python3-lark-parser</build_depend>
   <build_depend>std_msgs</build_depend>
 
   <exec_depend>rosidl_default_runtime</exec_depend>
   <exec_depend>python3-empy</exec_depend>
-  <exec_depend>python3-lark</exec_depend>
+  <exec_depend>python3-lark-parser</exec_depend>
   <exec_depend>std_msgs</exec_depend>
 
   <member_of_group>rosidl_interface_packages</member_of_group>


### PR DESCRIPTION
## Summary
- update the altinet_interfaces package manifest to depend on the python3-lark-parser rosdep key

## Testing
- rosdep update *(fails: command not found)*
- rosdep install --from-paths ros2_ws/src --ignore-src -r -y *(not run: rosdep unavailable)*

------
https://chatgpt.com/codex/tasks/task_e_68e1f7ceefe4832fbd6f367f75e90341