### PR TITLE
Ensure ROS message generation depends on lark

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Django backend for dashboards and historical analysis.
    http://127.0.0.1:8000/ with the admin at http://127.0.0.1:8000/admin/.
 
 3. Build the ROS 2 workspace (requires ROS 2 Foxy/Humble and `colcon`).
-   Install ROS package dependencies (including `python3-lark`) with `rosdep`
-   before invoking `colcon build`:
+   Install ROS package dependencies with `rosdep` before invoking
+   `colcon build`. The Python requirements already vendor
+   `lark`, so the message generation tooling resolves correctly even when
+   you're working inside a virtual environment:
 
    ```bash
    cd ros2_ws

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,3 +25,4 @@ flake8>=6.1
 mypy>=1.6
 types-requests
 types-python-dateutil
+lark>=1.1,<2.0


### PR DESCRIPTION
## Summary
- add the lark parser to the Python requirements so ROS message generation works inside a venv
- update the README to clarify that the Python requirements already vendor lark

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f908dbbc832fb2d3b056aac8fdb2