### PR TITLE
Enhance detector identity logging diagnostics

### DIFF
--- a/ros2_ws/src/altinet/altinet/nodes/detector_node.py
+++ b/ros2_ws/src/altinet/altinet/nodes/detector_node.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+import math
 import time
 from collections import deque
 from datetime import datetime
 from functools import partial
 from pathlib import Path
-from typing import Deque, List, Optional
+from typing import Any, Deque, List, Optional
 
 import numpy as np
 
@@ -39,6 +40,69 @@ from ..utils.config import default_yolo_config_path, load_file, package_path
 from ..utils.models import YoloConfig, YoloV8Detector
 from ..utils.ros_conversions import detections_to_msg
 from ..utils.types import Detection
+
+
+def _safe_float(value: Any) -> Optional[float]:
+    """Return ``value`` coerced to ``float`` if possible."""
+
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if math.isnan(numeric) or math.isinf(numeric):
+        return None
+    return numeric
+
+
+def format_identity_log_message(detection: Detection, response: Any) -> str:
+    """Return a human-readable log message for an identity response.
+
+    The identity service may expose additional fields depending on the
+    interface version.  This helper gracefully adds diagnostic details when
+    they are present while keeping the legacy format intact when they are not
+    available.
+    """
+
+    label = getattr(response, "label", "") or (
+        "user" if bool(getattr(response, "is_user", False)) else "guest"
+    )
+    confidence = _safe_float(getattr(response, "confidence", 0.0)) or 0.0
+    reason = getattr(response, "reason", "")
+    bbox = detection.bbox
+
+    message = (
+        f"Identity check for detection in room '{detection.room_id}' "
+        f"(frame '{detection.frame_id}') at x={bbox.x:.1f}, y={bbox.y:.1f} -> "
+        f"{label} (confidence {confidence:.2f}). {reason}"
+    )
+
+    details: List[str] = []
+
+    embedding_id = getattr(response, "embedding_id", None)
+    if isinstance(embedding_id, str):
+        embedding_id = embedding_id.strip()
+    if embedding_id not in {None, ""}:
+        details.append(f"embedding_id={embedding_id}")
+
+    similarity = _safe_float(getattr(response, "embedding_similarity", None))
+    if similarity is not None:
+        details.append(f"similarity={similarity:.3f}")
+
+    snapshot_age = _safe_float(getattr(response, "snapshot_age", None))
+    if snapshot_age is not None:
+        details.append(f"snapshot_age={snapshot_age:.2f}s")
+
+    if hasattr(response, "used_face_embedding"):
+        used = getattr(response, "used_face_embedding")
+        if isinstance(used, bool):
+            details.append(f"used_face_embedding={str(used).lower()}")
+        elif used not in {None, ""}:
+            details.append(f"used_face_embedding={used}")
+
+    if details:
+        message += f" [details: {', '.join(details)}]"
+
+    return message
 
 
 class DetectorPipeline:
@@ -262,17 +326,16 @@ class DetectorNode(Node):  # pragma: no cover - requires ROS runtime
             )
             return
 
-        label = response.label or ("user" if response.is_user else "guest")
-        bbox = detection.bbox
-        message = (
-            f"Identity check for detection in room '{detection.room_id}' "
-            f"(frame '{detection.frame_id}') at x={bbox.x:.1f}, y={bbox.y:.1f} -> "
-            f"{label} (confidence {response.confidence:.2f}). {response.reason}"
-        )
+        message = format_identity_log_message(detection, response)
         self.get_logger().info(message)
 
 
-__all__ = ["DetectorPipeline", "DetectorNode", "load_config"]
+__all__ = [
+    "DetectorPipeline",
+    "DetectorNode",
+    "format_identity_log_message",
+    "load_config",
+]
 
 
 def main(args=None):  # pragma: no cover - requires ROS runtime

--- a/ros2_ws/src/altinet/altinet/tests/test_detector.py
+++ b/ros2_ws/src/altinet/altinet/tests/test_detector.py
@@ -5,7 +5,13 @@ from pathlib import Path
 
 import numpy as np
 
-from altinet.nodes.detector_node import DetectorPipeline, load_config
+from types import SimpleNamespace
+
+from altinet.nodes.detector_node import (
+    DetectorPipeline,
+    format_identity_log_message,
+    load_config,
+)
 from altinet.utils.models import _focus_close_range_detection_on_head, _scale_box
 from altinet.utils.types import BoundingBox, Detection
 
@@ -97,3 +103,54 @@ def test_focus_close_range_detection_keeps_regular_boxes():
     adjusted = _focus_close_range_detection_on_head(box, image_shape)
 
     assert adjusted == box
+
+
+def make_detection() -> Detection:
+    return Detection(
+        bbox=BoundingBox(82.3, 73.8, 245.7, 180.4),
+        confidence=0.92,
+        room_id="room_1",
+        frame_id="room_1",
+        timestamp=datetime.utcnow(),
+        image_size=(480, 640),
+    )
+
+
+def test_format_identity_log_message_retains_legacy_format():
+    detection = make_detection()
+    response = SimpleNamespace(
+        label="",
+        is_user=True,
+        confidence=1.0,
+        reason="No face embedding available; area ratio 0.1443 >= threshold 0.0200",
+    )
+
+    message = format_identity_log_message(detection, response)
+
+    assert (
+        message
+        == "Identity check for detection in room 'room_1' (frame 'room_1') "
+        "at x=82.3, y=73.8 -> user (confidence 1.00). "
+        "No face embedding available; area ratio 0.1443 >= threshold 0.0200"
+    )
+
+
+def test_format_identity_log_message_includes_optional_details():
+    detection = make_detection()
+    response = SimpleNamespace(
+        label="user",
+        is_user=True,
+        confidence=0.87,
+        reason="cosine similarity 0.912 >= threshold 0.700",
+        embedding_id="resident_1",
+        embedding_similarity=0.9123,
+        snapshot_age=1.2345,
+        used_face_embedding=True,
+    )
+
+    message = format_identity_log_message(detection, response)
+
+    assert "embedding_id=resident_1" in message
+    assert "similarity=0.912" in message
+    assert "snapshot_age=1.23s" in message
+    assert "used_face_embedding=true" in message


### PR DESCRIPTION
## Summary
- add a helper to format identity check log messages with optional diagnostics from the identity service
- extend detector unit tests to cover legacy formatting and the new diagnostic fields

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e72c0216dc832fb8809f51362efcb1