### PR TITLE
Handle invalid camera bridge responses

### DIFF
--- a/backend/spaces/tests/test_views.py
+++ b/backend/spaces/tests/test_views.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import json
 import pytest
 from django.contrib.auth.models import User
+from rest_framework import status
 
 from spaces.models import Camera, CameraCalibrationRun
 
@@ -157,6 +158,42 @@ def test_camera_endpoints(monkeypatch, api_client, room):
     assert response.status_code == 200
     camera = Camera.objects.get(id=camera_id)
     assert camera.intrinsics["fx"] == 1.0
+
+
+@pytest.mark.django_db
+def test_camera_test_connection_handles_invalid_bridge_response(
+    monkeypatch, api_client, room
+):
+    class DummyBridge:
+        def probe_camera(self, camera_id: str):
+            return {"message": "bridge unavailable"}
+
+    monkeypatch.setattr("spaces.views.ROSBridgeClient", lambda: DummyBridge())
+
+    camera = Camera.objects.create(
+        name="Unhealthy Cam",
+        room=room,
+        make="Generic",
+        model="Cam",
+        rtsp_url="rtsp://user:pass@cam/stream",
+        resolution_w=1920,
+        resolution_h=1080,
+        fps=30,
+        fov_deg=90.0,
+        position_mm={"x_mm": 0, "y_mm": 0, "z_mm": 2000},
+        yaw_deg=0.0,
+        pitch_deg=0.0,
+        roll_deg=0.0,
+    )
+
+    response = api_client.post(
+        f"/api/cameras/{camera.id}/test-connection/", {}, format="json"
+    )
+
+    assert response.status_code == status.HTTP_502_BAD_GATEWAY
+    assert response.data["detail"] == "Invalid bridge response"
+    assert "ok" in response.data["errors"]
+    assert response.data["raw"] == {"message": "bridge unavailable"}
 
 
 @pytest.mark.django_db

--- a/backend/spaces/views.py
+++ b/backend/spaces/views.py
@@ -97,7 +97,14 @@ class CameraViewSet(viewsets.ModelViewSet):
         serializer = CameraTestConnectionSerializer(data=payload)
         if serializer.is_valid():
             return Response(serializer.validated_data)
-        return Response(payload)
+        return Response(
+            {
+                "detail": "Invalid bridge response",
+                "errors": serializer.errors,
+                "raw": payload,
+            },
+            status=status.HTTP_502_BAD_GATEWAY,
+        )
 
     @action(detail=True, methods=["post"], url_path="calibration/start")
     def calibration_start(self, request, pk: str | None = None) -> Response:


### PR DESCRIPTION
## Summary
- return a gateway error when the ROS bridge test-connection response is invalid
- include error details and raw payload for easier debugging
- add regression test covering unexpected bridge responses

## Testing
- pytest backend/spaces/tests/test_views.py -q


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f5e853834832faf21242bbd5bd523)